### PR TITLE
feat: Make asm builtin take arguments as a tuple

### DIFF
--- a/lib/oxi/builtin/lib.oxi
+++ b/lib/oxi/builtin/lib.oxi
@@ -1,6 +1,6 @@
 /// Returns isize if the constraints include a return register, otherwise returns void
 #[internal]
-pub extern fn @asm(asm: []u8, constraints: []u8, ...) any;
+pub extern fn @asm(asm: []u8, constraints: []u8, arguments: (..)) any;
 
 /// Returns a struct representing the module
 #[internal]

--- a/lib/oxi/std/lib.oxi
+++ b/lib/oxi/std/lib.oxi
@@ -2,6 +2,6 @@ pub fn print(str: []u8) void {
     @asm(
       "mov rax, 1\nmov rdi, 1\nmov rsi, $0\nmov rdx, $1\nsyscall",
       "r,r,~{rax},~{rdi},~{rsi},~{rdx},~{rcx},~{r11},~{cc}",
-      str.ptr, str.len
+      (str.ptr, str.len),
     );
 }

--- a/src/codegen/builtin/asm.rs
+++ b/src/codegen/builtin/asm.rs
@@ -33,15 +33,21 @@ impl BuiltinFunction for AsmBuiltin {
             _ => unreachable!(),
         };
 
-        let (asm_str, constraints) = match (&expr.arguments[0].kind, &expr.arguments[1].kind) {
-            (ExprKind::String(asm), ExprKind::String(cons)) => (asm, cons),
+        let (asm_str, constraints, arguments) = match (
+            &expr.arguments[0].kind,
+            &expr.arguments[1].kind,
+            &expr.arguments[2].kind,
+        ) {
+            (ExprKind::String(asm), ExprKind::String(cons), ExprKind::TupleLiteral(args)) => {
+                (asm, cons, args)
+            }
             _ => bail!("First two arguments must be string literals"),
         };
 
         let mut operands: Vec<BasicMetadataValueEnum> = Vec::new();
         let mut metadata_types: Vec<BasicMetadataTypeEnum> = Vec::new();
 
-        for arg in &expr.arguments[2..] {
+        for arg in &arguments.elements {
             let val =
                 compile_expression_to_value(context, module, builder, arg, compilation_context)?;
             let val = val.unwrap(builder)?;

--- a/src/codegen/builtin/asm.rs
+++ b/src/codegen/builtin/asm.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow};
 use inkwell::{
     InlineAsmDialect,
     builder::Builder,

--- a/src/codegen/builtin/asm.rs
+++ b/src/codegen/builtin/asm.rs
@@ -41,7 +41,9 @@ impl BuiltinFunction for AsmBuiltin {
             (ExprKind::String(asm), ExprKind::String(cons), ExprKind::TupleLiteral(args)) => {
                 (asm, cons, args)
             }
-            _ => bail!("First two arguments must be string literals"),
+            _ => bail!(
+                "Invalid arguments to asm builtin, expected @asm(string, string, tuple) (First 2 arguments must be available at compile time)"
+            ),
         };
 
         let mut operands: Vec<BasicMetadataValueEnum> = Vec::new();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the inline assembly macro to accept its extra inputs as a single grouped argument rather than as separate/variadic parameters.
  * Adjusted call sites to pass grouped argument tuples, keeping behavior the same while standardizing argument packaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->