### PR TITLE
refactor: Make blocks expressions

### DIFF
--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -318,7 +318,7 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
                     }
                 }
                 writeln!(out)?;
-                write_fn_decl(out, &fn_decl, &sub_ctx)?;
+                write_fn_decl(out, fn_decl, &sub_ctx)?;
             }
         }
         StmtKind::Return(return_stmt) => {

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -157,8 +157,9 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
         StmtKind::Expression(expr_stmt) => {
             write!(
                 out,
-                "{} {}:",
+                "{}{} {}:",
                 "ExpressionStmt".with_color(ctx.color),
+                punct_with_color(if expr_stmt.has_semicolon { ";" } else { "" }, ctx.color),
                 node_id_with_color(id, ctx.color)
             )?;
             if expr_stmt.expression.kind.is_leaf() {

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -418,7 +418,7 @@ fn write_struct_method(
         }
     }
     writeln!(out)?;
-    write_fn_decl(out, &method.fn_decl, ctx)?;
+    write_fn_decl(out, &method.fn_decl, &sub_ctx)?;
     Ok(())
 }
 
@@ -440,7 +440,7 @@ fn write_fn_decl(out: &mut String, fn_decl: &FnDeclStmt, ctx: &DisplayContext) -
                     }
                 }
             }
-            _ => panic!("Expected block expression, got {:?}", body.kind),
+            _ => panic!("Expected block expression, got {:?}", body.kind), // This should never happen
         }
     } else {
         writeln!(out)?;
@@ -496,7 +496,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             write!(
                 out,
                 "{} {}",
-                "BlockStmt".with_color(ctx.color),
+                "BlockExpr".with_color(ctx.color),
                 node_id_with_color(id, ctx.color)
             )?;
             write!(out, ":")?;

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -154,27 +154,6 @@ fn escape_string(s: &str) -> String {
 pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::fmt::Result {
     let id = stmt.id.0;
     match &stmt.kind {
-        StmtKind::Block(block) => {
-            write!(
-                out,
-                "{} {}",
-                "BlockStmt".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
-            write!(out, ":")?;
-            if block.body.is_empty() {
-                writeln!(out)?;
-                write!(out, "{}  (empty)", ctx.indent_str())?;
-            } else {
-                writeln!(out)?;
-                let body_ctx = ctx.indented();
-                for s in &block.body {
-                    write!(out, "{}", body_ctx.indent_str())?;
-                    write_stmt(out, s, &body_ctx)?;
-                    writeln!(out)?;
-                }
-            }
-        }
         StmtKind::Expression(expr_stmt) => {
             write!(
                 out,
@@ -315,7 +294,7 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             write!(out, " {} ", punct_with_color("->", ctx.color))?;
             write!(out, "{}", write_type(&fn_decl.return_type, ctx))?;
             write!(out, ":")?;
-            if fn_decl.arguments.is_empty() && fn_decl.body.is_empty() {
+            if fn_decl.arguments.is_empty() && fn_decl.body.is_none() {
                 write!(out, " (empty)")?;
             } else {
                 writeln!(out)?;
@@ -339,19 +318,7 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
                     }
                 }
                 writeln!(out)?;
-                write!(out, "{}Body:", sub_ctx.indent_str())?;
-                if fn_decl.body.is_empty() {
-                    writeln!(out)?;
-                    write!(out, "{}  (empty)", sub_ctx.indent_str())?;
-                } else {
-                    writeln!(out)?;
-                    let body_ctx = sub_ctx.indented();
-                    for s in &fn_decl.body {
-                        write!(out, "{}", body_ctx.indent_str())?;
-                        write_stmt(out, s, &body_ctx)?;
-                        writeln!(out)?;
-                    }
-                }
+                write_fn_decl(out, &fn_decl, &sub_ctx)?;
             }
         }
         StmtKind::Return(return_stmt) => {
@@ -451,18 +418,33 @@ fn write_struct_method(
         }
     }
     writeln!(out)?;
-    write!(out, "{}Body:", indent,)?;
-    if method.fn_decl.body.is_empty() {
-        writeln!(out)?;
-        write!(out, "{}  (empty)", indent)?;
+    write_fn_decl(out, &method.fn_decl, ctx)?;
+    Ok(())
+}
+
+fn write_fn_decl(out: &mut String, fn_decl: &FnDeclStmt, ctx: &DisplayContext) -> std::fmt::Result {
+    write!(out, "{}Body:", ctx.indent_str())?;
+    if let Some(body) = &fn_decl.body {
+        match &body.kind {
+            ExprKind::Block(body) => {
+                if body.body.is_empty() {
+                    writeln!(out)?;
+                    write!(out, "{}  (empty)", ctx.indent_str())?;
+                } else {
+                    writeln!(out)?;
+                    let body_ctx = ctx.indented();
+                    for s in &body.body {
+                        write!(out, "{}", body_ctx.indent_str())?;
+                        write_stmt(out, s, &body_ctx)?;
+                        writeln!(out)?;
+                    }
+                }
+            }
+            _ => panic!("Expected block expression, got {:?}", body.kind),
+        }
     } else {
         writeln!(out)?;
-        let body_ctx = sub_ctx.indented();
-        for s in &method.fn_decl.body {
-            write!(out, "{}", body_ctx.indent_str())?;
-            write_stmt(out, s, &body_ctx)?;
-            writeln!(out)?;
-        }
+        write!(out, "{}  (none)", ctx.indent_str())?;
     }
     Ok(())
 }
@@ -510,6 +492,27 @@ fn write_interface_method(
 fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::Result {
     let id = expr.id.0;
     match &expr.kind {
+        ExprKind::Block(block) => {
+            write!(
+                out,
+                "{} {}",
+                "BlockStmt".with_color(ctx.color),
+                node_id_with_color(id, ctx.color)
+            )?;
+            write!(out, ":")?;
+            if block.body.is_empty() {
+                writeln!(out)?;
+                write!(out, "{}  (empty)", ctx.indent_str())?;
+            } else {
+                writeln!(out)?;
+                let body_ctx = ctx.indented();
+                for s in &block.body {
+                    write!(out, "{}", body_ctx.indent_str())?;
+                    write_stmt(out, s, &body_ctx)?;
+                    writeln!(out)?;
+                }
+            }
+        }
         ExprKind::Number(num) => {
             write!(
                 out,

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -1,8 +1,13 @@
 use crate::{
-    ast::{Expr, Ident, Type},
+    ast::{Expr, Ident, Stmt, Type},
     lexer::token::Token,
 };
 use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct BlockExpr {
+    pub body: Box<[Stmt]>,
+}
 
 // TODO: Add float support, replace i32
 #[derive(Debug, Clone)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -49,7 +49,6 @@ pub struct Stmt {
 
 #[derive(Debug, Clone)]
 pub enum StmtKind {
-    Block(BlockStmt),
     Expression(ExpressionStmt),
     VarDecl(VarDeclStmt),
     StructDecl(StructDeclStmt),
@@ -82,6 +81,7 @@ pub enum ExprKind {
     Type(TypeExpr),
     As(AsExpr),
     TupleLiteral(TupleLiteralExpr),
+    Block(BlockExpr),
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -1,9 +1,4 @@
-use crate::ast::{Expr, Ident, ImportTree, Stmt, Type};
-
-#[derive(Debug, Clone)]
-pub struct BlockStmt {
-    pub body: Vec<Stmt>,
-}
+use crate::ast::{Expr, Ident, ImportTree, Type};
 
 #[derive(Debug, Clone)]
 pub struct ExpressionStmt {
@@ -37,8 +32,8 @@ pub struct StructMethod {
 #[derive(Debug, Clone)]
 pub struct StructDeclStmt {
     pub name: Ident,
-    pub properties: Vec<StructProperty>,
-    pub methods: Vec<StructMethod>,
+    pub properties: Box<[StructProperty]>,
+    pub methods: Box<[StructMethod]>,
     pub is_public: bool,
 }
 
@@ -50,7 +45,7 @@ pub struct InterfaceMethod {
 #[derive(Debug, Clone)]
 pub struct InterfaceDeclStmt {
     pub name: Ident,
-    pub methods: Vec<InterfaceMethod>,
+    pub methods: Box<[InterfaceMethod]>,
     pub is_public: bool,
 }
 
@@ -63,8 +58,8 @@ pub struct FnArgument {
 #[derive(Debug, Clone)]
 pub struct FnDeclStmt {
     pub name: Ident,
-    pub arguments: Vec<FnArgument>,
-    pub body: Vec<Stmt>,
+    pub arguments: Box<[FnArgument]>,
+    pub body: Option<Expr>,
     pub return_type: Type,
     pub is_public: bool,
     pub is_extern: bool,

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -3,6 +3,7 @@ use crate::ast::{Expr, Ident, ImportTree, Type};
 #[derive(Debug, Clone)]
 pub struct ExpressionStmt {
     pub expression: Expr,
+    pub has_semicolon: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -548,7 +548,10 @@ mod tests {
 
     fn dummy_stmt_expr(expr: Expr) -> Stmt {
         Stmt {
-            kind: StmtKind::Expression(ExpressionStmt { expression: expr }),
+            kind: StmtKind::Expression(ExpressionStmt {
+                expression: expr,
+                has_semicolon: true,
+            }),
             id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
@@ -1408,6 +1411,7 @@ mod tests {
                                             id: NodeId(0),
                                             span: dummy_span(),
                                         },
+                                        has_semicolon: true,
                                     }),
                                     id: NodeId(0),
                                     span: dummy_span(),

--- a/src/codegen/builtin/asm.rs
+++ b/src/codegen/builtin/asm.rs
@@ -87,7 +87,12 @@ impl BuiltinFunction for AsmBuiltin {
         let call_site_value = builder.build_indirect_call(fn_type, inline_asm, &operands, "asm")?;
 
         Ok(if ret_void {
-            SmartValue::from_value(context.i32_type().const_zero().as_basic_value_enum())
+            SmartValue::from_value(
+                context
+                    .struct_type(&[], false)
+                    .get_undef()
+                    .as_basic_value_enum(),
+            )
         } else {
             SmartValue::from_value(
                 call_site_value

--- a/src/codegen/builtin/import/header.rs
+++ b/src/codegen/builtin/import/header.rs
@@ -72,7 +72,7 @@ pub fn compile_header<'ctx>(
                         },
                         type_: arg,
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Box<[_]>>();
 
             let location = e.get_location().expect("function has no location");
             let (span, _module_id) = convert_clang_location(location);
@@ -81,7 +81,7 @@ pub fn compile_header<'ctx>(
                 kind: StmtKind::FnDecl(FnDeclStmt {
                     name: Ident { value: name, span },
                     arguments,
-                    body: Vec::new(),
+                    body: None,
                     return_type: ty.0,
                     is_public: true,
                     is_extern: true,

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -16,7 +16,7 @@ use crate::{
         arch::compile_arch_size_type,
         builtin::{Builtin, get_builtin},
         compile_type::{cast_int_to_type, compile_type},
-        compiler::CompilationContext,
+        compiler::{CompilationContext, compile_stmts},
         pointer::SmartValue,
     },
     lexer::token::TokenKind,
@@ -416,6 +416,21 @@ pub fn compile_expression_to_value<'a, 'ctx>(
             let slice_val = builder.build_insert_value(slice_val, len_val, 1, "slice_len")?;
 
             SmartValue::from_value(slice_val.as_basic_value_enum())
+        }
+        ExprKind::Block(block) => {
+            let mut inner_compilation_context = compilation_context.clone();
+            compile_stmts(
+                context,
+                module,
+                builder,
+                &block.body,
+                &mut inner_compilation_context,
+            )?;
+            SmartValue::from_value(
+                compile_arch_size_type(context)
+                    .const_int(0, false)
+                    .as_basic_value_enum(),
+            )
         }
         expr => unimplemented!("{expr:#?}"),
     })

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -417,6 +417,7 @@ pub fn compile_expression_to_value<'a, 'ctx>(
 
             SmartValue::from_value(slice_val.as_basic_value_enum())
         }
+        // TODO: Return the value of the last expression in the block
         ExprKind::Block(block) => {
             let mut inner_compilation_context = compilation_context.clone();
             compile_stmts(

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -251,7 +251,7 @@ fn compile_function<'ctx>(
                     &mut inner_compilation_context,
                 )?;
             }
-            _ => panic!("Expected block expression, got {:?}", body.kind),
+            _ => bail!("Expected block expression, got {:?}", body.kind),
         }
     }
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -7,7 +7,7 @@ use crate::{
     ast::{
         Expr, ExprKind, Ident,
         expressions::{
-            ArrayLiteralExpr, AsExpr, AssignmentExpr, BinaryExpr, FunctionCallExpr,
+            ArrayLiteralExpr, AsExpr, AssignmentExpr, BinaryExpr, BlockExpr, FunctionCallExpr,
             MemberAccessExpr, NumberExpr, PostfixExpr, PrefixExpr, StringExpr,
             StructInstantiationExpr, SymbolExpr, TupleLiteralExpr, TypeExpr,
         },
@@ -17,6 +17,7 @@ use crate::{
     parser::{
         Parser,
         lookups::{BP_LU, BindingPower, LED_LU, NUD_LU},
+        stmt::parse_stmt,
         string::process_string,
         types::parse_type,
         utils::unexpected_token,
@@ -352,4 +353,27 @@ pub fn parse_parenthesis_expr(parser: &mut Parser) -> Result<Expr> {
             Span::new(start_token.span.start(), end_span.end()),
         ))
     }
+}
+
+pub fn parse_block_expr(parser: &mut Parser) -> Result<Expr> {
+    let start_token = parser.expect(TokenKind::OpenCurly)?;
+    let mut body = Vec::new();
+
+    loop {
+        if parser.current_token().kind == TokenKind::CloseCurly {
+            break;
+        }
+
+        body.push(parse_stmt(parser)?);
+    }
+
+    let end_token = parser.expect(TokenKind::CloseCurly)?;
+    let span = Span::new(start_token.span.start(), end_token.span.end());
+
+    Ok(parser.expr(
+        ExprKind::Block(BlockExpr {
+            body: body.into_boxed_slice(),
+        }),
+        span,
+    ))
 }

--- a/src/parser/lookups.rs
+++ b/src/parser/lookups.rs
@@ -216,6 +216,7 @@ pub fn create_token_lookups() {
         nud(T::StringLiteral, parse_primary_expr, &mut nud_lu);
         nud(T::Identifier, parse_primary_expr, &mut nud_lu);
         nud(T::OpenParen, parse_parenthesis_expr, &mut nud_lu);
+        nud(T::OpenCurly, parse_block_expr, &mut nud_lu);
         nud(T::Dash, parse_prefix_expr, &mut nud_lu);
         nud(T::Reference, parse_prefix_expr, &mut nud_lu);
         nud(T::Dollar, parse_type_expr, &mut nud_lu);

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -358,12 +358,12 @@ pub fn parse_fn_decl_stmt(
         }
     }
 
-    let mut end_span = parser.expect(TokenKind::CloseParen)?.span;
+    parser.expect(TokenKind::CloseParen)?;
 
     let return_type = parse_type(parser, BindingPower::DefaultBp)?;
+    let mut end_span = return_type.span;
 
     let mut body: Option<Expr> = None;
-
     if parser.current_token().kind == TokenKind::OpenCurly {
         let expr = parse_expr(parser, BindingPower::DefaultBp)?;
         end_span = expr.span;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,24 @@ use common::it;
 use oxic::errors::ErrorLevel;
 
 #[test]
+fn can_compile_simple_nested_block() {
+    it(|ctx| {
+        ctx.add_source(
+            r#"
+            pub fn main() void {
+                {
+                    {
+                        {};
+                    };
+                };
+            }
+            "#,
+        )
+        .compiles(true);
+    })
+}
+
+#[test]
 fn duplicate_struct_property_fails() {
     it(|ctx| {
         ctx.add_source(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,6 +3,40 @@ mod common;
 use common::it;
 use oxic::errors::ErrorLevel;
 
+// TODO: This is supported by the parser, but not by the codegen
+#[ignore]
+#[test]
+fn can_compile_interface_declaration() {
+    it(|ctx| {
+        ctx.add_source(
+            r#"
+            interface Foo {
+                fn bar() void,
+            }
+            "#,
+        )
+        .compiles(true);
+    })
+}
+
+#[test]
+fn can_compile_nested_block_with_implicit_returns() {
+    it(|ctx| {
+        ctx.add_source(
+            r#"
+            pub fn main() void {
+                {
+                    {
+                        {}
+                    }
+                }
+            }
+            "#,
+        )
+        .compiles(true);
+    })
+}
+
 #[test]
 fn can_compile_simple_nested_block() {
     it(|ctx| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block expressions are now parsed, displayed, and compiled; nested blocks yield values.

* **Refactor**
  * Block and function-body handling consolidated into a single shared flow.
  * Reduced memory overhead for several declaration collections; function bodies now use an optional expression form.

* **Tests**
  * Added integration tests covering nested and simple block compilation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->