### PR TITLE
refactor: Remove node IDs

### DIFF
--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -83,11 +83,6 @@ fn punct_with_color(s: &str, color: bool) -> String {
     }
 }
 
-fn node_id_with_color(n: usize, color: bool) -> String {
-    let s = format!("#{}", n);
-    if color { s.dimmed().to_string() } else { s }
-}
-
 fn write_expr_inline_or_nested(
     out: &mut String,
     label: &str,
@@ -152,15 +147,13 @@ fn escape_string(s: &str) -> String {
 }
 
 pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::fmt::Result {
-    let id = stmt.id.0;
     match &stmt.kind {
         StmtKind::Expression(expr_stmt) => {
             write!(
                 out,
-                "{}{} {}:",
+                "{}{}:",
                 "ExpressionStmt".with_color(ctx.color),
                 punct_with_color(if expr_stmt.has_semicolon { ";" } else { "" }, ctx.color),
-                node_id_with_color(id, ctx.color)
             )?;
             if expr_stmt.expression.kind.is_leaf() {
                 write!(out, " ")?;
@@ -186,9 +179,8 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             let modifiers = format_modifiers(&modifiers);
             write!(
                 out,
-                "{} {} {}{}{}{}: ",
+                "{} {}{}{}{}: ",
                 "VarDecl".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 modifiers_with_color(&modifiers, ctx.color),
                 punct_with_color("\"", ctx.color),
                 var_decl.variable_name.value,
@@ -218,9 +210,8 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             let modifiers = format_modifiers(&modifiers);
             write!(
                 out,
-                "{} {} {}{}{}",
+                "{} {}{}{}",
                 "StructDecl".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 modifiers_with_color(&modifiers, ctx.color),
                 punct_with_color("\"", ctx.color),
                 struct_decl.name.value
@@ -256,9 +247,8 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             let modifiers = format_modifiers(&modifiers);
             write!(
                 out,
-                "{} {} {}{}{}",
+                "{} {}{}{}",
                 "InterfaceDecl".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 modifiers_with_color(&modifiers, ctx.color),
                 punct_with_color("\"", ctx.color),
                 interface_decl.name.value
@@ -286,9 +276,8 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             let modifiers = format_modifiers(&modifiers);
             write!(
                 out,
-                "{} {} {}\"{}\"",
+                "{} {}\"{}\"",
                 "FnDecl".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 modifiers_with_color(&modifiers, ctx.color),
                 fn_decl.name.value
             )?;
@@ -310,9 +299,8 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
                     for arg in &fn_decl.arguments {
                         writeln!(
                             out,
-                            "{}FnArg {} \"{}\": {}",
+                            "{}FnArg \"{}\": {}",
                             arg_ctx.indent_str(),
-                            node_id_with_color(arg.type_.id.0, ctx.color),
                             arg.name.value,
                             write_type(&arg.type_, &arg_ctx)
                         )?;
@@ -323,12 +311,7 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             }
         }
         StmtKind::Return(return_stmt) => {
-            write!(
-                out,
-                "{} {}:",
-                "Return".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            write!(out, "{}:", "Return".with_color(ctx.color),)?;
             if let Some(value) = &return_stmt.value {
                 writeln!(out)?;
                 let value_ctx = ctx.indented();
@@ -339,12 +322,7 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
             }
         }
         StmtKind::Import(import_stmt) => {
-            write!(
-                out,
-                "{} {}: ",
-                "Import".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            write!(out, "{}: ", "Import".with_color(ctx.color),)?;
             write_import_tree(out, &import_stmt.tree, ctx)?;
         }
     }
@@ -363,9 +341,8 @@ fn write_struct_property(
     let modifiers = format_modifiers(&modifiers);
     write!(
         out,
-        "{} {} {}\"{}\": ",
+        "{} {}\"{}\": ",
         "Property".with_color(ctx.color),
-        node_id_with_color(prop.type_.id.0, ctx.color),
         modifiers_with_color(&modifiers, ctx.color),
         prop.name.value
     )?;
@@ -410,9 +387,8 @@ fn write_struct_method(
         for arg in &method.fn_decl.arguments {
             writeln!(
                 out,
-                "{}FnArg {} \"{}\": {}",
+                "{}FnArg \"{}\": {}",
                 arg_ctx.indent_str(),
-                node_id_with_color(arg.type_.id.0, ctx.color),
                 arg.name.value,
                 write_type(&arg.type_, &arg_ctx)
             )?;
@@ -478,9 +454,8 @@ fn write_interface_method(
         for arg in &method.fn_decl.arguments {
             writeln!(
                 out,
-                "{}FnArg {} \"{}\": {}",
+                "{}FnArg \"{}\": {}",
                 arg_ctx.indent_str(),
-                node_id_with_color(arg.type_.id.0, ctx.color),
                 arg.name.value,
                 write_type(&arg.type_, &arg_ctx)
             )?;
@@ -491,15 +466,9 @@ fn write_interface_method(
 }
 
 fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::Result {
-    let id = expr.id.0;
     match &expr.kind {
         ExprKind::Block(block) => {
-            write!(
-                out,
-                "{} {}",
-                "BlockExpr".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            write!(out, "{}", "BlockExpr".with_color(ctx.color),)?;
             write!(out, ":")?;
             if block.body.is_empty() {
                 writeln!(out)?;
@@ -517,39 +486,31 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
         ExprKind::Number(num) => {
             write!(
                 out,
-                "{} {}: {}",
+                "{}: {}",
                 "Number".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 number_with_color(&num.value.to_string(), ctx.color)
             )?;
         }
         ExprKind::String(s) => {
             write!(
                 out,
-                "{} {}: {}",
+                "{}: {}",
                 "String".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 string_with_color(&s.value, ctx.color)
             )?;
         }
         ExprKind::Symbol(s) => {
             write!(
                 out,
-                "{} {} {}{}{}",
+                "{} {}{}{}",
                 "Symbol".with_color(ctx.color),
-                node_id_with_color(id, ctx.color),
                 punct_with_color("\"", ctx.color),
                 s.value.value,
                 punct_with_color("\"", ctx.color)
             )?;
         }
         ExprKind::Binary(b) => {
-            writeln!(
-                out,
-                "{} {}",
-                "Binary".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "Binary".with_color(ctx.color))?;
             let expr_ctx = ctx.indented();
             writeln!(out, "{}Left:", expr_ctx.indent_str())?;
             write!(out, "{}", expr_ctx.indent_str())?;
@@ -568,12 +529,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             write_expr(out, &b.right, &expr_ctx)?;
         }
         ExprKind::Postfix(p) => {
-            writeln!(
-                out,
-                "{} {}",
-                "Postfix".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "Postfix".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             writeln!(out, "{}Left:", expr_ctx.indent_str())?;
             write!(out, "{}", expr_ctx.indent_str())?;
@@ -587,12 +543,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             )?;
         }
         ExprKind::Prefix(p) => {
-            writeln!(
-                out,
-                "{} {}",
-                "Prefix".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "Prefix".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             writeln!(out, "{}Operator:", expr_ctx.indent_str())?;
             write!(
@@ -608,12 +559,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             write_expr(out, &p.right, &expr_ctx)?;
         }
         ExprKind::Assignment(a) => {
-            writeln!(
-                out,
-                "{} {}",
-                "Assignment".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "Assignment".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             writeln!(out, "{}Assignee:", expr_ctx.indent_str())?;
             write!(out, "{}", expr_ctx.indent_str())?;
@@ -632,12 +578,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             write_expr(out, &a.value, &expr_ctx)?;
         }
         ExprKind::StructInstantiation(s) => {
-            write!(
-                out,
-                "{} {}",
-                "StructInstantiation".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            write!(out, "{}", "StructInstantiation".with_color(ctx.color),)?;
             write!(out, " \"{}\"", s.name.value)?;
             if s.properties.is_empty() {
                 write!(out, ": (empty)")?;
@@ -654,12 +595,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             }
         }
         ExprKind::ArrayLiteral(a) => {
-            writeln!(
-                out,
-                "{} {}",
-                "ArrayLiteral".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "ArrayLiteral".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             write!(
                 out,
@@ -684,12 +620,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             }
         }
         ExprKind::FunctionCall(call) => {
-            writeln!(
-                out,
-                "{} {}",
-                "FunctionCall".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "FunctionCall".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             write_expr_inline_or_nested(out, "Callee: ", &call.callee, &expr_ctx)?;
             writeln!(out)?;
@@ -709,12 +640,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             }
         }
         ExprKind::MemberAccess(m) => {
-            writeln!(
-                out,
-                "{} {}",
-                "MemberAccess".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "MemberAccess".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             write_expr_inline_or_nested(out, "Base: ", &m.base, &expr_ctx)?;
             writeln!(out)?;
@@ -726,22 +652,12 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             )?;
         }
         ExprKind::Type(t) => {
-            write!(
-                out,
-                "{} {}",
-                "Type".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            write!(out, "{}", "Type".with_color(ctx.color),)?;
             write!(out, ": ")?;
             write!(out, "{}", write_type(&t.underlying, ctx))?;
         }
         ExprKind::As(a) => {
-            writeln!(
-                out,
-                "{} {}",
-                "As".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            writeln!(out, "{}", "As".with_color(ctx.color),)?;
             let expr_ctx = ctx.indented();
             writeln!(out, "{}Expr:", expr_ctx.indent_str())?;
             write!(out, "{}", expr_ctx.indent_str())?;
@@ -752,12 +668,7 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
             write!(out, "{}", write_type(&a.ty, &expr_ctx))?;
         }
         ExprKind::TupleLiteral(t) => {
-            write!(
-                out,
-                "{} {}",
-                "TupleLiteral".with_color(ctx.color),
-                node_id_with_color(id, ctx.color)
-            )?;
+            write!(out, "{}", "TupleLiteral".with_color(ctx.color),)?;
             if t.elements.is_empty() {
                 write!(out, ": (empty)")?;
             } else {
@@ -831,7 +742,7 @@ fn write_import_tree(
         }
         ImportTreeKind::Nested { items, .. } => {
             write!(out, "{}::{}", path_str, punct_with_color("{", ctx.color))?;
-            for (i, (item, _)) in items.iter().enumerate() {
+            for (i, item) in items.iter().enumerate() {
                 if i > 0 {
                     write!(out, ", ")?;
                 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -29,9 +29,6 @@ impl Ast {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Copy)]
-pub struct NodeId(pub usize);
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Attribute {
     pub name: Ident,
@@ -42,7 +39,6 @@ pub struct Attribute {
 #[derive(Debug, Clone)]
 pub struct Stmt {
     pub kind: StmtKind,
-    pub id: NodeId,
     pub span: Span,
     pub attributes: Box<[Attribute]>,
 }
@@ -61,7 +57,6 @@ pub enum StmtKind {
 #[derive(Debug, Clone)]
 pub struct Expr {
     pub kind: ExprKind,
-    pub id: NodeId,
     pub span: Span,
 }
 
@@ -87,7 +82,6 @@ pub enum ExprKind {
 #[derive(Debug, Clone)]
 pub struct Type {
     pub kind: TypeKind,
-    pub id: NodeId,
     pub span: Span,
 }
 
@@ -145,7 +139,7 @@ pub enum ImportTreeKind {
     ///             ^^^^^^^^^^
     /// ```
     Nested {
-        items: Box<[(ImportTree, NodeId)]>,
+        items: Box<[ImportTree]>,
         span: Span,
     },
     /// `import prefix::*`

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -344,7 +344,7 @@ impl Visitable for TupleType {
 mod tests {
     use super::*;
     use crate::{
-        ast::{Ident, ImportTree, ImportTreeKind, NodeId, Path},
+        ast::{Ident, ImportTree, ImportTreeKind, Path},
         span::{ModuleId, Span},
     };
     use std::collections::HashMap;
@@ -497,7 +497,6 @@ mod tests {
             kind: TypeKind::Symbol(SymbolType {
                 name: dummy_ident(name),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         }
     }
@@ -505,7 +504,6 @@ mod tests {
     fn dummy_type_infer() -> Type {
         Type {
             kind: TypeKind::Infer,
-            id: NodeId(0),
             span: dummy_span(),
         }
     }
@@ -513,7 +511,6 @@ mod tests {
     fn dummy_type_never() -> Type {
         Type {
             kind: TypeKind::Never,
-            id: NodeId(0),
             span: dummy_span(),
         }
     }
@@ -521,7 +518,6 @@ mod tests {
     fn dummy_expr_number(value: i32) -> Expr {
         Expr {
             kind: ExprKind::Number(NumberExpr { value }),
-            id: NodeId(0),
             span: dummy_span(),
         }
     }
@@ -531,7 +527,6 @@ mod tests {
             kind: ExprKind::Symbol(SymbolExpr {
                 value: dummy_ident(name),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         }
     }
@@ -541,7 +536,6 @@ mod tests {
             kind: ExprKind::Block(BlockExpr {
                 body: body.into_boxed_slice(),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         }
     }
@@ -552,7 +546,6 @@ mod tests {
                 expression: expr,
                 has_semicolon: true,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         }
@@ -573,7 +566,6 @@ mod tests {
             kind: ExprKind::String(StringExpr {
                 value: "hello".to_string().into_boxed_str(),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -599,7 +591,6 @@ mod tests {
                 operator: dummy_token(crate::lexer::token::TokenKind::Plus),
                 right: Box::new(dummy_expr_number(2)),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -616,7 +607,6 @@ mod tests {
                 left: Box::new(dummy_expr_symbol("x")),
                 operator: dummy_token(crate::lexer::token::TokenKind::Plus),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -633,7 +623,6 @@ mod tests {
                 operator: dummy_token(crate::lexer::token::TokenKind::NotEquals),
                 right: Box::new(dummy_expr_symbol("x")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -651,7 +640,6 @@ mod tests {
                 operator: dummy_token(crate::lexer::token::TokenKind::Equals),
                 value: Box::new(dummy_expr_number(1)),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -669,7 +657,6 @@ mod tests {
                 name: dummy_ident("Foo"),
                 properties: HashMap::from([(dummy_ident("a"), dummy_expr_number(1))]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -690,7 +677,6 @@ mod tests {
                     (dummy_ident("c"), dummy_expr_number(3)),
                 ]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -711,7 +697,6 @@ mod tests {
                     dummy_expr_number(3),
                 ]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -730,7 +715,6 @@ mod tests {
                 callee: Box::new(dummy_expr_symbol("foo")),
                 arguments: Box::new([dummy_expr_number(1), dummy_expr_number(2)]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -748,7 +732,6 @@ mod tests {
                 base: Box::new(dummy_expr_symbol("obj")),
                 member: dummy_ident("field"),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -764,7 +747,6 @@ mod tests {
             kind: ExprKind::Type(TypeExpr {
                 underlying: dummy_type_symbol("i32"),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -782,7 +764,6 @@ mod tests {
                 expr: Box::new(dummy_expr_number(1)),
                 ty: dummy_type_symbol("i32"),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -804,7 +785,6 @@ mod tests {
                     dummy_expr_number(3),
                 ]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -858,7 +838,6 @@ mod tests {
                 type_: dummy_type_symbol("i32"),
                 is_static: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -883,7 +862,6 @@ mod tests {
                 type_: dummy_type_symbol("i32"),
                 is_static: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -904,7 +882,6 @@ mod tests {
                 methods: Box::new([]),
                 is_public: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -935,7 +912,6 @@ mod tests {
                 methods: Box::new([]),
                 is_public: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -961,7 +937,6 @@ mod tests {
                         arguments: Box::new([]),
                         body: Some(Expr {
                             kind: ExprKind::Block(BlockExpr { body: Box::new([]) }),
-                            id: NodeId(0),
                             span: dummy_span(),
                         }),
                         return_type: dummy_type_never(),
@@ -972,7 +947,6 @@ mod tests {
                 .into_boxed_slice(),
                 is_public: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -1002,7 +976,6 @@ mod tests {
                 .into_boxed_slice(),
                 is_public: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -1034,14 +1007,12 @@ mod tests {
                     kind: ExprKind::Block(BlockExpr {
                         body: vec![dummy_stmt_expr(dummy_expr_number(1))].into_boxed_slice(),
                     }),
-                    id: NodeId(0),
                     span: dummy_span(),
                 }),
                 return_type: dummy_type_symbol("void"),
                 is_public: false,
                 is_extern: false,
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -1063,7 +1034,6 @@ mod tests {
             kind: StmtKind::Return(ReturnStmt {
                 value: Some(dummy_expr_number(1)),
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -1079,7 +1049,6 @@ mod tests {
     fn test_return_stmt_no_value() {
         let mut stmt = Stmt {
             kind: StmtKind::Return(ReturnStmt { value: None }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -1102,7 +1071,6 @@ mod tests {
                     span: dummy_span(),
                 },
             }),
-            id: NodeId(0),
             span: dummy_span(),
             attributes: Box::new([]),
         };
@@ -1145,7 +1113,6 @@ mod tests {
             kind: TypeKind::Pointer(PointerType {
                 underlying: Box::new(dummy_type_symbol("i32")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -1161,7 +1128,6 @@ mod tests {
             kind: TypeKind::Slice(SliceType {
                 underlying: Box::new(dummy_type_symbol("i32")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -1178,7 +1144,6 @@ mod tests {
                 length: 10,
                 underlying: Box::new(dummy_type_symbol("i32")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -1194,7 +1159,6 @@ mod tests {
             kind: TypeKind::Mut(MutType {
                 underlying: Box::new(dummy_type_symbol("i32")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -1211,7 +1175,6 @@ mod tests {
                 parameters: Box::new([dummy_type_symbol("i32"), dummy_type_symbol("bool")]),
                 return_type: Box::new(dummy_type_symbol("void")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -1227,7 +1190,6 @@ mod tests {
             kind: TypeKind::Tuple(TupleType {
                 elements: Box::new([dummy_type_symbol("i32"), dummy_type_symbol("bool")]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
         let mut visitor = NodeCounterVisitor::new();
@@ -1259,13 +1221,11 @@ mod tests {
                                             ),
                                             right: Box::new(dummy_expr_number(4)),
                                         }),
-                                        id: NodeId(0),
                                         span: dummy_span(),
                                     },
                                 ),
                             ]),
                         }),
-                        id: NodeId(0),
                         span: dummy_span(),
                     },
                     Expr {
@@ -1275,16 +1235,13 @@ mod tests {
                                 kind: TypeKind::Pointer(PointerType {
                                     underlying: Box::new(dummy_type_symbol("i32")),
                                 }),
-                                id: NodeId(0),
                                 span: dummy_span(),
                             },
                         }),
-                        id: NodeId(0),
                         span: dummy_span(),
                     },
                 ]),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
 
@@ -1315,7 +1272,6 @@ mod tests {
                         span: dummy_span(),
                     },
                 }),
-                id: NodeId(0),
                 span: dummy_span(),
                 attributes: Box::new([]),
             },
@@ -1339,7 +1295,6 @@ mod tests {
                                     body: vec![dummy_stmt_expr(dummy_expr_number(1))]
                                         .into_boxed_slice(),
                                 }),
-                                id: NodeId(0),
                                 span: dummy_span(),
                             }),
                             return_type: dummy_type_never(),
@@ -1350,7 +1305,6 @@ mod tests {
                     .into_boxed_slice(),
                     is_public: false,
                 }),
-                id: NodeId(0),
                 span: dummy_span(),
                 attributes: Box::new([]),
             },
@@ -1370,7 +1324,6 @@ mod tests {
                     .into_boxed_slice(),
                     is_public: false,
                 }),
-                id: NodeId(0),
                 span: dummy_span(),
                 attributes: Box::new([]),
             },
@@ -1390,7 +1343,6 @@ mod tests {
                                         type_: dummy_type_infer(),
                                         is_static: false,
                                     }),
-                                    id: NodeId(0),
                                     span: dummy_span(),
                                     attributes: Box::new([]),
                                 },
@@ -1402,32 +1354,27 @@ mod tests {
                                                     kind: StmtKind::Return(ReturnStmt {
                                                         value: Some(dummy_expr_number(2)),
                                                     }),
-                                                    id: NodeId(0),
                                                     span: dummy_span(),
                                                     attributes: Box::new([]),
                                                 }]
                                                 .into_boxed_slice(),
                                             }),
-                                            id: NodeId(0),
                                             span: dummy_span(),
                                         },
                                         has_semicolon: true,
                                     }),
-                                    id: NodeId(0),
                                     span: dummy_span(),
                                     attributes: Box::new([]),
                                 },
                             ]
                             .into_boxed_slice(),
                         }),
-                        id: NodeId(0),
                         span: dummy_span(),
                     }),
                     return_type: dummy_type_symbol("isize"),
                     is_public: false,
                     is_extern: false,
                 }),
-                id: NodeId(0),
                 span: dummy_span(),
                 attributes: Box::new([]),
             },
@@ -1459,18 +1406,15 @@ mod tests {
                                 kind: TypeKind::Mut(MutType {
                                     underlying: Box::new(dummy_type_symbol("i32")),
                                 }),
-                                id: NodeId(0),
                                 span: dummy_span(),
                             }),
                         }),
-                        id: NodeId(0),
                         span: dummy_span(),
                     },
                     Type {
                         kind: TypeKind::Slice(SliceType {
                             underlying: Box::new(dummy_type_symbol("u8")),
                         }),
-                        id: NodeId(0),
                         span: dummy_span(),
                     },
                     Type {
@@ -1478,7 +1422,6 @@ mod tests {
                             length: 10,
                             underlying: Box::new(dummy_type_symbol("bool")),
                         }),
-                        id: NodeId(0),
                         span: dummy_span(),
                     },
                 ]),
@@ -1490,11 +1433,9 @@ mod tests {
                             dummy_type_symbol("void"),
                         ]),
                     }),
-                    id: NodeId(0),
                     span: dummy_span(),
                 }),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
 
@@ -1527,7 +1468,6 @@ mod tests {
                                 operator: dummy_token(crate::lexer::token::TokenKind::Plus),
                                 right: Box::new(dummy_expr_symbol("b")),
                             }),
-                            id: NodeId(0),
                             span: dummy_span(),
                         }),
                         operator: dummy_token(crate::lexer::token::TokenKind::Star),
@@ -1537,17 +1477,14 @@ mod tests {
                                 operator: dummy_token(crate::lexer::token::TokenKind::Slash),
                                 right: Box::new(dummy_expr_symbol("d")),
                             }),
-                            id: NodeId(0),
                             span: dummy_span(),
                         }),
                     }),
-                    id: NodeId(0),
                     span: dummy_span(),
                 }),
                 operator: dummy_token(crate::lexer::token::TokenKind::Dash),
                 right: Box::new(dummy_expr_symbol("e")),
             }),
-            id: NodeId(0),
             span: dummy_span(),
         };
 

--- a/src/codegen/builtin/import/header.rs
+++ b/src/codegen/builtin/import/header.rs
@@ -4,7 +4,7 @@ use inkwell::{builder::Builder, context::Context, module::Module};
 
 use crate::{
     ast::{
-        Ast, Ident, NodeId, Stmt, StmtKind, Type, TypeKind,
+        Ast, Ident, Stmt, StmtKind, Type, TypeKind,
         statements::{FnArgument, FnDeclStmt},
         types::SymbolType,
     },
@@ -16,22 +16,6 @@ use crate::{
     span::{ModuleId, Span},
 };
 use std::fs;
-
-struct NodeIdManager {
-    next_id: NodeId,
-}
-
-impl NodeIdManager {
-    fn new() -> Self {
-        Self { next_id: NodeId(0) }
-    }
-
-    fn next_id(&mut self) -> NodeId {
-        let id = self.next_id;
-        self.next_id = NodeId(self.next_id.0 + 1);
-        id
-    }
-}
 
 pub fn compile_header<'ctx>(
     context: &'ctx Context,
@@ -50,17 +34,14 @@ pub fn compile_header<'ctx>(
     let index = Index::new(&clang, false, false);
     let tu = index.parser(module_path.clone()).parse()?;
 
-    let mut nid_mgr = NodeIdManager::new();
-
     let mut ast: Vec<Stmt> = Vec::new();
 
-    for (i, e) in tu.get_entity().get_children().iter().enumerate() {
+    for e in tu.get_entity().get_children().iter() {
         if e.get_kind() == EntityKind::FunctionDecl {
             let name = parse_function_name(e.get_display_name().expect("function has no name"))
                 .expect("function has no name")
                 .into();
-            let ty =
-                parse_function_type(e.get_type().expect("function has no type"), &mut nid_mgr)?;
+            let ty = parse_function_type(e.get_type().expect("function has no type"))?;
 
             let arguments =
                 ty.1.into_iter()
@@ -86,7 +67,6 @@ pub fn compile_header<'ctx>(
                     is_public: true,
                     is_extern: true,
                 }),
-                id: NodeId(i),
                 span,
                 attributes: Box::new([]),
             };
@@ -123,7 +103,7 @@ fn parse_function_name(name: String) -> Option<String> {
     name.split_once('(').map(|(name, _)| name.to_string())
 }
 
-fn parse_function_type(ty: clang::Type, nid_mgr: &mut NodeIdManager) -> Result<(Type, Vec<Type>)> {
+fn parse_function_type(ty: clang::Type) -> Result<(Type, Vec<Type>)> {
     let return_type = ty.get_result_type().expect("function type is not valid");
     let args = ty.get_argument_types().unwrap_or_default();
 
@@ -136,8 +116,7 @@ fn parse_function_type(ty: clang::Type, nid_mgr: &mut NodeIdManager) -> Result<(
                 .get_location()
                 .expect("argument has no location");
             let (span, _) = convert_clang_location(loc);
-            let id = nid_mgr.next_id();
-            parse_type(&arg.get_display_name(), id, span)
+            parse_type(&arg.get_display_name(), span)
         })
         .collect();
 
@@ -147,13 +126,12 @@ fn parse_function_type(ty: clang::Type, nid_mgr: &mut NodeIdManager) -> Result<(
         .get_location()
         .expect("return type has no location");
     let (span, _) = convert_clang_location(loc);
-    let id = nid_mgr.next_id();
-    let return_type = parse_type(&return_type.get_display_name(), id, span);
+    let return_type = parse_type(&return_type.get_display_name(), span);
 
     Ok((return_type, arg_types))
 }
 
-fn parse_type(ty: &str, id: NodeId, span: Span) -> Type {
+fn parse_type(ty: &str, span: Span) -> Type {
     let ty = map_c_type(ty);
 
     Type {
@@ -163,7 +141,6 @@ fn parse_type(ty: &str, id: NodeId, span: Span) -> Type {
                 span,
             },
         }),
-        id,
         span,
     }
 }

--- a/src/codegen/builtin/import/header.rs
+++ b/src/codegen/builtin/import/header.rs
@@ -110,12 +110,11 @@ fn parse_function_type(ty: clang::Type) -> Result<(Type, Vec<Type>)> {
     let arg_types: Vec<Type> = args
         .iter()
         .map(|arg| {
-            let loc = arg
+            let span = arg
                 .get_declaration()
-                .expect("argument has no location")
-                .get_location()
-                .expect("argument has no location");
-            let (span, _) = convert_clang_location(loc);
+                .and_then(|decl| decl.get_location())
+                .map(|loc| convert_clang_location(loc).0)
+                .unwrap_or(Span::new(0, 0));
             parse_type(&arg.get_display_name(), span)
         })
         .collect();

--- a/src/codegen/builtin/import/header.rs
+++ b/src/codegen/builtin/import/header.rs
@@ -119,12 +119,11 @@ fn parse_function_type(ty: clang::Type) -> Result<(Type, Vec<Type>)> {
         })
         .collect();
 
-    let loc = return_type
+    let span = return_type
         .get_declaration()
-        .expect("return type has no location")
-        .get_location()
-        .expect("return type has no location");
-    let (span, _) = convert_clang_location(loc);
+        .and_then(|decl| decl.get_location())
+        .map(|loc| convert_clang_location(loc).0)
+        .unwrap_or(Span::new(0, 0));
     let return_type = parse_type(&return_type.get_display_name(), span);
 
     Ok((return_type, arg_types))

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -392,12 +392,11 @@ pub fn compile_expression_to_value<'a, 'ctx>(
                 )?
             };
 
-            // TODO: This is a temporary hack to get an id and span for a built-in type
+            // TODO: This is a temporary hack to get a span for a built-in type
             let slice_ty = Type {
                 kind: TypeKind::Slice(SliceType {
                     underlying: Box::new(ar_expr.underlying.clone()),
                 }),
-                id: expr.id,
                 span: expr.span,
             };
 

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -20,6 +20,7 @@ use crate::{
         pointer::SmartValue,
     },
     lexer::token::TokenKind,
+    span::Span,
 };
 
 pub fn compile_expression_to_value<'a, 'ctx>(
@@ -392,12 +393,11 @@ pub fn compile_expression_to_value<'a, 'ctx>(
                 )?
             };
 
-            // TODO: This is a temporary hack to get a span for a built-in type
             let slice_ty = Type {
                 kind: TypeKind::Slice(SliceType {
                     underlying: Box::new(ar_expr.underlying.clone()),
                 }),
-                span: expr.span,
+                span: Span::new(expr.span.start(), ar_expr.underlying.span.end()),
             };
 
             let slice_llvm_type = compile_type(context, &slice_ty, compilation_context)?;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -61,9 +61,7 @@ macro_rules! emit_at {
                     span, module_id,
                 )?)
                 .add_widget($crate::errors::widgets::CodeWidget::new(
-                    span,
-                    module_id,
-                    $highlight,
+                    span, module_id, $highlight,
                 )?);
             let builder = if let Some(info) = $info {
                 builder.add_widget($crate::errors::widgets::InfoWidget::new(

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -344,10 +344,9 @@ pub fn parse_parenthesis_expr(parser: &mut Parser) -> Result<Expr> {
     let end_span = close_token.span;
 
     if expressions.len() == 1 && !has_comma {
-        Ok(Expr {
-            kind: expressions[0].kind.clone(),
-            span: Span::new(start_token.span.start(), end_span.end()),
-        })
+        let mut expr = expressions.pop().unwrap();
+        expr.span = Span::new(start_token.span.start(), end_span.end());
+        Ok(expr)
     } else {
         Ok(Expr {
             kind: ExprKind::TupleLiteral(TupleLiteralExpr {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -71,24 +71,24 @@ pub fn parse_primary_expr(parser: &mut Parser) -> Result<Expr> {
     let span = token.span;
 
     match token.kind {
-        TokenKind::Number => Ok(parser.expr(
-            ExprKind::Number(NumberExpr {
+        TokenKind::Number => Ok(Expr {
+            kind: ExprKind::Number(NumberExpr {
                 value: value.parse::<i32>()?,
             }),
             span,
-        )),
-        TokenKind::StringLiteral => Ok(parser.expr(
-            ExprKind::String(StringExpr {
+        }),
+        TokenKind::StringLiteral => Ok(Expr {
+            kind: ExprKind::String(StringExpr {
                 value: process_string(&value, span, token.module_id).into(),
             }),
             span,
-        )),
-        TokenKind::Identifier => Ok(parser.expr(
-            ExprKind::Symbol(SymbolExpr {
+        }),
+        TokenKind::Identifier => Ok(Expr {
+            kind: ExprKind::Symbol(SymbolExpr {
                 value: TryInto::<Ident>::try_into(token)?,
             }),
             span,
-        )),
+        }),
         _ => unreachable!(),
     }
 }
@@ -98,14 +98,14 @@ pub fn parse_binary_expr(parser: &mut Parser, left: Expr, bp: BindingPower) -> R
     let right = parse_expr(parser, bp)?;
 
     let span = Span::new(left.span.start(), right.span.end());
-    Ok(parser.expr(
-        ExprKind::Binary(BinaryExpr {
+    Ok(Expr {
+        kind: ExprKind::Binary(BinaryExpr {
             left: Box::new(left),
             operator,
             right: Box::new(right),
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_postfix_expr(parser: &mut Parser, left: Expr, _bp: BindingPower) -> Result<Expr> {
@@ -118,13 +118,13 @@ pub fn parse_postfix_expr(parser: &mut Parser, left: Expr, _bp: BindingPower) ->
     let operator = parser.advance();
 
     let span = Span::new(left.span.start(), operator.span.end());
-    Ok(parser.expr(
-        ExprKind::Postfix(PostfixExpr {
+    Ok(Expr {
+        kind: ExprKind::Postfix(PostfixExpr {
             left: Box::new(left),
             operator,
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr> {
@@ -132,13 +132,13 @@ pub fn parse_prefix_expr(parser: &mut Parser) -> Result<Expr> {
     let right = parse_expr(parser, BindingPower::DefaultBp)?;
 
     let span = Span::new(operator.span.start(), right.span.end());
-    Ok(parser.expr(
-        ExprKind::Prefix(PrefixExpr {
+    Ok(Expr {
+        kind: ExprKind::Prefix(PrefixExpr {
             operator,
             right: Box::new(right),
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_assignment_expr(
@@ -150,14 +150,14 @@ pub fn parse_assignment_expr(
     let value = parse_expr(parser, BindingPower::Assignment)?;
 
     let span = Span::new(assigne.span.start(), value.span.end());
-    Ok(parser.expr(
-        ExprKind::Assignment(AssignmentExpr {
+    Ok(Expr {
+        kind: ExprKind::Assignment(AssignmentExpr {
             assigne: Box::new(assigne),
             operator,
             value: Box::new(value),
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_struct_instantiation_expr(
@@ -193,13 +193,13 @@ pub fn parse_struct_instantiation_expr(
     let close_token = parser.expect(TokenKind::CloseCurly)?;
 
     let span = Span::new(left.span.start(), close_token.span.end());
-    Ok(parser.expr(
-        ExprKind::StructInstantiation(StructInstantiationExpr {
+    Ok(Expr {
+        kind: ExprKind::StructInstantiation(StructInstantiationExpr {
             name: struct_name,
             properties,
         }),
         span,
-    ))
+    })
 }
 
 // TODO: This only parses slices, not arrays
@@ -229,13 +229,13 @@ pub fn parse_array_literal_expr(parser: &mut Parser) -> Result<Expr> {
     let close_token = parser.expect(TokenKind::CloseCurly)?;
     let span = Span::new(start_token.span.start(), close_token.span.end());
 
-    Ok(parser.expr(
-        ExprKind::ArrayLiteral(ArrayLiteralExpr {
+    Ok(Expr {
+        kind: ExprKind::ArrayLiteral(ArrayLiteralExpr {
             underlying: type_,
             contents: contents.into_boxed_slice(),
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_function_call_expr(
@@ -262,13 +262,13 @@ pub fn parse_function_call_expr(
     parser.expect(TokenKind::CloseParen)?;
 
     let span = Span::new(left.span.start(), parser.current_token().span.end());
-    Ok(parser.expr(
-        ExprKind::FunctionCall(FunctionCallExpr {
+    Ok(Expr {
+        kind: ExprKind::FunctionCall(FunctionCallExpr {
             callee: Box::new(left),
             arguments: arguments.into_boxed_slice(),
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_member_access_expr(
@@ -282,13 +282,13 @@ pub fn parse_member_access_expr(
     let member_span = member.span;
 
     let span = Span::new(left.span.start(), member_span.end());
-    Ok(parser.expr(
-        ExprKind::MemberAccess(MemberAccessExpr {
+    Ok(Expr {
+        kind: ExprKind::MemberAccess(MemberAccessExpr {
             base: Box::new(left),
             member,
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_type_expr(parser: &mut Parser) -> Result<Expr> {
@@ -299,7 +299,10 @@ pub fn parse_type_expr(parser: &mut Parser) -> Result<Expr> {
     let end_token = parser.current_token();
     let span = Span::new(start_token.span.start(), end_token.span.end());
 
-    Ok(parser.expr(ExprKind::Type(TypeExpr { underlying: ty }), span))
+    Ok(Expr {
+        kind: ExprKind::Type(TypeExpr { underlying: ty }),
+        span,
+    })
 }
 
 pub fn parse_as_cast_expr(parser: &mut Parser, left: Expr, _bp: BindingPower) -> Result<Expr> {
@@ -308,13 +311,13 @@ pub fn parse_as_cast_expr(parser: &mut Parser, left: Expr, _bp: BindingPower) ->
     let ty = parse_type(parser, BindingPower::DefaultBp)?;
 
     let span = Span::new(left.span.start(), ty.span.end());
-    Ok(parser.expr(
-        ExprKind::As(AsExpr {
+    Ok(Expr {
+        kind: ExprKind::As(AsExpr {
             expr: Box::new(left),
             ty,
         }),
         span,
-    ))
+    })
 }
 
 pub fn parse_parenthesis_expr(parser: &mut Parser) -> Result<Expr> {
@@ -341,17 +344,17 @@ pub fn parse_parenthesis_expr(parser: &mut Parser) -> Result<Expr> {
     let end_span = close_token.span;
 
     if expressions.len() == 1 && !has_comma {
-        Ok(parser.expr(
-            expressions[0].kind.clone(),
-            Span::new(start_token.span.start(), end_span.end()),
-        ))
+        Ok(Expr {
+            kind: expressions[0].kind.clone(),
+            span: Span::new(start_token.span.start(), end_span.end()),
+        })
     } else {
-        Ok(parser.expr(
-            ExprKind::TupleLiteral(TupleLiteralExpr {
+        Ok(Expr {
+            kind: ExprKind::TupleLiteral(TupleLiteralExpr {
                 elements: expressions.into_boxed_slice(),
             }),
-            Span::new(start_token.span.start(), end_span.end()),
-        ))
+            span: Span::new(start_token.span.start(), end_span.end()),
+        })
     }
 }
 
@@ -370,10 +373,10 @@ pub fn parse_block_expr(parser: &mut Parser) -> Result<Expr> {
     let end_token = parser.expect(TokenKind::CloseCurly)?;
     let span = Span::new(start_token.span.start(), end_token.span.end());
 
-    Ok(parser.expr(
-        ExprKind::Block(BlockExpr {
+    Ok(Expr {
+        kind: ExprKind::Block(BlockExpr {
             body: body.into_boxed_slice(),
         }),
         span,
-    ))
+    })
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,11 +8,10 @@ mod types;
 mod utils;
 
 use crate::{
-    ast::{Ast, Attribute, Expr, ExprKind, Ident, NodeId, Stmt, StmtKind, Type, TypeKind},
+    ast::{Ast, Ident, Stmt},
     fatal_at,
     lexer::token::{Token, TokenKind, TokenStream},
     parser::{lookups::create_token_lookups, stmt::parse_stmt, types::create_token_type_lookups},
-    span::Span,
 };
 
 use anyhow::Result;
@@ -21,7 +20,6 @@ use std::convert::TryInto;
 pub struct Parser {
     tokens: Box<[Token]>,
     pos: usize,
-    next_id: NodeId,
 }
 
 impl Parser {
@@ -29,39 +27,7 @@ impl Parser {
         Parser {
             tokens: tokens.into_boxed_slice(),
             pos: 0,
-            next_id: NodeId(0),
         }
-    }
-
-    pub fn stmt(&mut self, kind: StmtKind, span: Span, attributes: Box<[Attribute]>) -> Stmt {
-        Stmt {
-            id: self.next_id(),
-            kind,
-            span,
-            attributes,
-        }
-    }
-
-    pub fn expr(&mut self, kind: ExprKind, span: Span) -> Expr {
-        Expr {
-            id: self.next_id(),
-            kind,
-            span,
-        }
-    }
-
-    pub fn type_(&mut self, kind: TypeKind, span: Span) -> Type {
-        Type {
-            id: self.next_id(),
-            kind,
-            span,
-        }
-    }
-
-    pub fn next_id(&mut self) -> NodeId {
-        let id = self.next_id;
-        self.next_id = NodeId(self.next_id.0 + 1);
-        id
     }
 
     pub fn tokens(&self) -> &[Token] {

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -437,13 +437,21 @@ pub fn parse_fn_decl_stmt(
 pub fn parse_return_stmt(
     parser: &mut Parser,
     attributes: &[Attribute],
-    _modifiers: &[Modifier],
+    modifiers: &[Modifier],
 ) -> Result<Stmt> {
     if !attributes.is_empty() {
         error_at!(
             attributes[0].span,
             parser.current_token().module_id,
             "Attribute not allowed here"
+        )?;
+    }
+
+    if !modifiers.is_empty() {
+        error_at!(
+            modifiers[0].span,
+            parser.current_token().module_id,
+            "Modifier not allowed here"
         )?;
     }
 

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -521,13 +521,16 @@ fn parse_import_tree_list(parser: &mut Parser) -> Result<Box<[ImportTree]>> {
     loop {
         items.push(parse_import_tree(parser)?);
 
-        if parser.peek().kind != TokenKind::CloseCurly
-            && parser.current_token().kind == TokenKind::Comma
-        {
-            parser.expect(TokenKind::Comma)?;
+        if parser.current_token().kind == TokenKind::CloseCurly {
+            break;
         }
 
-        if parser.current_token().kind == TokenKind::CloseCurly {
+        if parser.current_token().kind == TokenKind::Comma {
+            parser.advance();
+            if parser.current_token().kind == TokenKind::CloseCurly {
+                break;
+            }
+        } else {
             break;
         }
     }

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -436,9 +436,17 @@ pub fn parse_fn_decl_stmt(
 
 pub fn parse_return_stmt(
     parser: &mut Parser,
-    _attributes: &[Attribute],
+    attributes: &[Attribute],
     _modifiers: &[Modifier],
 ) -> Result<Stmt> {
+    if !attributes.is_empty() {
+        error_at!(
+            attributes[0].span,
+            parser.current_token().module_id,
+            "Attribute not allowed here"
+        )?;
+    }
+
     let return_token = parser.advance();
 
     let value = if parser.current_token().kind != TokenKind::Semicolon {

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -71,7 +71,10 @@ fn parse_symbol_type(parser: &mut Parser) -> Result<Type> {
     let ident = parser.expect_identifier()?;
     let span = ident.span;
 
-    Ok(parser.type_(TypeKind::Symbol(SymbolType { name: ident }), span))
+    Ok(Type {
+        kind: TypeKind::Symbol(SymbolType { name: ident }),
+        span,
+    })
 }
 
 fn parse_pointer_type(parser: &mut Parser) -> Result<Type> {
@@ -79,12 +82,12 @@ fn parse_pointer_type(parser: &mut Parser) -> Result<Type> {
     let underlying = parse_type(parser, BindingPower::DefaultBp)?;
     let end_span = underlying.span;
 
-    Ok(parser.type_(
-        TypeKind::Pointer(PointerType {
+    Ok(Type {
+        kind: TypeKind::Pointer(PointerType {
             underlying: Box::new(underlying),
         }),
-        Span::new(start_token.span.start(), end_span.end()),
-    ))
+        span: Span::new(start_token.span.start(), end_span.end()),
+    })
 }
 
 fn parse_array_type(parser: &mut Parser) -> Result<Type> {
@@ -98,25 +101,25 @@ fn parse_array_type(parser: &mut Parser) -> Result<Type> {
             let underlying = parse_type(parser, BP::DefaultBp)?;
             let end_span = underlying.span;
 
-            Ok(parser.type_(
-                TypeKind::FixedArray(FixedArrayType {
+            Ok(Type {
+                kind: TypeKind::FixedArray(FixedArrayType {
                     length,
                     underlying: Box::new(underlying),
                 }),
-                Span::new(start_token.span.start(), end_span.end()),
-            ))
+                span: Span::new(start_token.span.start(), end_span.end()),
+            })
         }
         T::CloseBracket => {
             parser.advance();
             let underlying = parse_type(parser, BP::DefaultBp)?;
             let end_span = underlying.span;
 
-            Ok(parser.type_(
-                TypeKind::Slice(SliceType {
+            Ok(Type {
+                kind: TypeKind::Slice(SliceType {
                     underlying: Box::new(underlying),
                 }),
-                Span::new(start_token.span.start(), end_span.end()),
-            ))
+                span: Span::new(start_token.span.start(), end_span.end()),
+            })
         }
         _ => Err(anyhow!(
             format!(
@@ -181,12 +184,12 @@ fn parse_mut_type(parser: &mut Parser) -> Result<Type> {
     let underlying = parse_type(parser, BindingPower::DefaultBp)?;
     let end_span = underlying.span;
 
-    Ok(parser.type_(
-        TypeKind::Mut(MutType {
+    Ok(Type {
+        kind: TypeKind::Mut(MutType {
             underlying: Box::new(underlying),
         }),
-        Span::new(start_token.span.start(), end_span.end()),
-    ))
+        span: Span::new(start_token.span.start(), end_span.end()),
+    })
 }
 
 fn parse_parenthesis_type(parser: &mut Parser) -> Result<Type> {
@@ -211,19 +214,19 @@ fn parse_parenthesis_type(parser: &mut Parser) -> Result<Type> {
         let return_type = parse_type(parser, BindingPower::DefaultBp)?;
         let end_span = return_type.span;
 
-        Ok(parser.type_(
-            TypeKind::Function(FunctionType {
+        Ok(Type {
+            kind: TypeKind::Function(FunctionType {
                 parameters: types.into_boxed_slice(),
                 return_type: Box::new(return_type),
             }),
-            Span::new(start_token.span.start(), end_span.end()),
-        ))
+            span: Span::new(start_token.span.start(), end_span.end()),
+        })
     } else {
-        Ok(parser.type_(
-            TypeKind::Tuple(TupleType {
+        Ok(Type {
+            kind: TypeKind::Tuple(TupleType {
                 elements: types.into_boxed_slice(),
             }),
-            Span::new(start_token.span.start(), close_token.span.end()),
-        ))
+            span: Span::new(start_token.span.start(), close_token.span.end()),
+        })
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -287,4 +287,3 @@ pub fn it(f: impl FnOnce(&mut Test)) {
     let mut test = Test::new();
     f(&mut test);
 }
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the internal per-node ID system, simplifying AST construction and propagation.
* **Display**
  * Textual output is cleaner — internal numeric node identifiers are no longer shown.
* **API**
  * Statements now carry an attributes container by default, exposing metadata on statements.
* **Style**
  * Minor formatting and parsing refinements for more consistent span and structure handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->