### PR TITLE
feat: Add break expression

### DIFF
--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -596,6 +596,16 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
                 }
             }
         }
+        ExprKind::Break(break_expr) => {
+            write!(out, "{}", "Break".with_color(ctx.color),)?;
+            if let Some(value) = &break_expr.value {
+                writeln!(out, ":")?;
+                let value_ctx = ctx.indented();
+                write!(out, "{}", value_ctx.indent_str())?;
+                write_expr(out, value, &value_ctx)?;
+            }
+        }
+
         ExprKind::Binary(b) => {
             writeln!(out, "{}", "Binary".with_color(ctx.color))?;
             let expr_ctx = ctx.indented();

--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -605,7 +605,6 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
                 write_expr(out, value, &value_ctx)?;
             }
         }
-
         ExprKind::Binary(b) => {
             writeln!(out, "{}", "Binary".with_color(ctx.color))?;
             let expr_ctx = ctx.indented();

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -100,3 +100,8 @@ pub struct WhileExpr {
 pub struct LoopExpr {
     pub body: Block,
 }
+
+#[derive(Debug, Clone)]
+pub struct BreakExpr {
+    pub value: Option<Box<Expr>>,
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -86,6 +86,7 @@ pub enum ExprKind {
     If(IfExpr),
     While(WhileExpr),
     Loop(LoopExpr),
+    Break(BreakExpr),
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -238,6 +238,7 @@ impl Visitable for Expr {
                 ExprKind::Type(t) => t.visit(visitor),
                 ExprKind::As(a) => a.visit(visitor),
                 ExprKind::TupleLiteral(t) => t.visit(visitor),
+                ExprKind::Break(b) => b.visit(visitor),
             },
             VisitAction::SkipChildren => {}
         }
@@ -274,6 +275,14 @@ impl Visitable for WhileExpr {
 impl Visitable for LoopExpr {
     fn visit(&self, visitor: &mut impl Visitor) {
         self.body.visit(visitor);
+    }
+}
+
+impl Visitable for BreakExpr {
+    fn visit(&self, visitor: &mut impl Visitor) {
+        if let Some(v) = &self.value {
+            v.visit(visitor);
+        }
     }
 }
 

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -1,19 +1,19 @@
 use std::path::PathBuf;
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use inkwell::{
-    AddressSpace,
     builder::Builder,
     context::Context,
     module::{Linkage, Module},
     types::{BasicType, BasicTypeEnum},
     values::{BasicValue, BasicValueEnum, FunctionValue},
+    AddressSpace,
 };
 
 use crate::{
     ast::{
-        Stmt, StmtKind, Type,
         statements::{ExprStmt, FnDeclStmt, ReturnStmt, StructDeclStmt, VarDeclStmt},
+        Stmt, StmtKind, Type,
     },
     bindings::llvm_bindings::create_named_struct,
     codegen::{

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -1,19 +1,19 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use inkwell::{
+    AddressSpace,
     builder::Builder,
     context::Context,
     module::{Linkage, Module},
     types::{BasicType, BasicTypeEnum},
     values::{BasicValue, BasicValueEnum, FunctionValue},
-    AddressSpace,
 };
 
 use crate::{
     ast::{
-        statements::{ExprStmt, FnDeclStmt, ReturnStmt, StructDeclStmt, VarDeclStmt},
         Stmt, StmtKind, Type,
+        statements::{ExprStmt, FnDeclStmt, ReturnStmt, StructDeclStmt, VarDeclStmt},
     },
     bindings::llvm_bindings::create_named_struct,
     codegen::{

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,14 +1,10 @@
 pub mod widgets;
 
-use std::{
-    fmt::{self, Display, Formatter},
-};
+use std::fmt::{self, Display, Formatter};
 
 use crate::{elog, elogln, hashmap::FxHashMap};
 
 use colored::Colorize;
-
-
 
 use crate::errors::widgets::Widget;
 

--- a/src/hir/lower.rs
+++ b/src/hir/lower.rs
@@ -668,7 +668,7 @@ impl LoweringContext {
                 let then_stmts = self.lower_body(w.body.stmts);
                 let then_branch = self.alloc_expr(HirExpr::Block { stmts: then_stmts });
 
-                let break_expr = self.alloc_expr(HirExpr::Break);
+                let break_expr = self.alloc_expr(HirExpr::Break { value: None });
                 let break_stmt = self.alloc_stmt(HirStmt::Semi(break_expr));
                 let else_branch = self.alloc_expr(HirExpr::Block {
                     stmts: thin_vec![break_stmt],
@@ -696,6 +696,10 @@ impl LoweringContext {
                     body,
                     source: LoopSource::Loop,
                 })
+            }
+            ExprKind::Break(b) => {
+                let value = b.value.map(|e| self.lower_expr(*e));
+                self.alloc_expr(HirExpr::Break { value })
             }
             _ => todo!("Lowering of {:?} not implemented", expr.kind),
         }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -246,7 +246,9 @@ pub enum HirExpr {
         body: BodyId,
         source: LoopSource,
     },
-    Break, // FIXME: Add `break` expr to AST and parser
+    Break {
+        value: Option<ExprId>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -448,3 +448,21 @@ pub fn parse_loop_expr(parser: &mut Parser) -> Result<Expr> {
         span,
     })
 }
+
+pub fn parse_break_expr(parser: &mut Parser) -> Result<Expr> {
+    let start_span = parser.expect(TokenKind::Break)?.span;
+
+    let value = if parser.current_token().kind != TokenKind::Semicolon {
+        Some(Box::new(parse_expr(parser, BindingPower::DefaultBp)?))
+    } else {
+        None
+    };
+
+    let end_span = value.as_ref().map(|v| v.span).unwrap_or(start_span);
+    let span = Span::new(start_span.start(), end_span.end());
+
+    Ok(Expr {
+        kind: ExprKind::Break(BreakExpr { value }),
+        span,
+    })
+}

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -452,7 +452,11 @@ pub fn parse_loop_expr(parser: &mut Parser) -> Result<Expr> {
 pub fn parse_break_expr(parser: &mut Parser) -> Result<Expr> {
     let start_span = parser.expect(TokenKind::Break)?.span;
 
-    let value = if parser.current_token().kind != TokenKind::Semicolon {
+    let current = parser.current_token().kind;
+    let value = if !matches!(
+        current,
+        TokenKind::Semicolon | TokenKind::CloseCurly | TokenKind::Comma
+    ) {
         Some(Box::new(parse_expr(parser, BindingPower::DefaultBp)?))
     } else {
         None

--- a/src/parser/lookups.rs
+++ b/src/parser/lookups.rs
@@ -274,6 +274,7 @@ pub fn create_token_lookups() {
         nud(T::If, parse_if_expr, &mut nud_lu);
         nud(T::While, parse_while_expr, &mut nud_lu);
         nud(T::Loop, parse_loop_expr, &mut nud_lu);
+        nud(T::Break, parse_break_expr, &mut nud_lu);
 
         // Statements
         stmt(T::Let, parse_var_decl_statement, &mut bp_lu, &mut stmt_lu);

--- a/src/span/sourcemaps.rs
+++ b/src/span/sourcemaps.rs
@@ -1,6 +1,9 @@
 use std::path::PathBuf;
 
-use crate::{hashmap::FxHashMap, span::{ModuleId, Span}};
+use crate::{
+    hashmap::FxHashMap,
+    span::{ModuleId, Span},
+};
 
 #[derive(Debug, Clone)]
 pub struct SourceMap {

--- a/tests/visit_tests.rs
+++ b/tests/visit_tests.rs
@@ -12,7 +12,7 @@ mod tests {
         lexer::token::{Token, TokenKind},
         span::{ModuleId, Span},
     };
-    use thin_vec::{ThinVec, thin_vec};
+    use thin_vec::{thin_vec, ThinVec};
 
     // Since this is only used for testing, using a string instead of an enum is fine.
     pub struct NodeCounterVisitor {
@@ -120,6 +120,7 @@ mod tests {
                 ExprKind::Type(_) => "TypeExpr",
                 ExprKind::As(_) => "AsExpr",
                 ExprKind::TupleLiteral(_) => "TupleLiteralExpr",
+                ExprKind::Break(_) => "BreakExpr",
             };
             *self.expr_counts.entry(kind_name).or_insert(0) += 1;
 

--- a/tests/visit_tests.rs
+++ b/tests/visit_tests.rs
@@ -12,7 +12,7 @@ mod tests {
         lexer::token::{Token, TokenKind},
         span::{ModuleId, Span},
     };
-    use thin_vec::{ThinVec, thin_vec};
+    use thin_vec::{thin_vec, ThinVec};
 
     // Since this is only used for testing, using a string instead of an enum is fine.
     pub struct NodeCounterVisitor {
@@ -511,6 +511,33 @@ mod tests {
         visitor.assert_visited("expr", "Expr", 4);
         visitor.assert_visited("expr", "TupleLiteralExpr", 1);
         visitor.assert_visited("expr", "NumberExpr", 3);
+    }
+
+    #[test]
+    fn test_break_expr_visited_once() {
+        let expr = Expr {
+            kind: ExprKind::Break(BreakExpr { value: None }),
+            span: dummy_span(),
+        };
+        let mut visitor = NodeCounterVisitor::new();
+        expr.visit(&mut visitor);
+        visitor.assert_visited("expr", "Expr", 1);
+        visitor.assert_visited("expr", "BreakExpr", 1);
+    }
+
+    #[test]
+    fn test_break_expr_with_value_visited() {
+        let expr = Expr {
+            kind: ExprKind::Break(BreakExpr {
+                value: Some(Box::new(dummy_expr_number(42))),
+            }),
+            span: dummy_span(),
+        };
+        let mut visitor = NodeCounterVisitor::new();
+        expr.visit(&mut visitor);
+        visitor.assert_visited("expr", "Expr", 2);
+        visitor.assert_visited("expr", "BreakExpr", 1);
+        visitor.assert_visited("expr", "NumberExpr", 1);
     }
 
     #[test]

--- a/tests/visit_tests.rs
+++ b/tests/visit_tests.rs
@@ -12,7 +12,7 @@ mod tests {
         lexer::token::{Token, TokenKind},
         span::{ModuleId, Span},
     };
-    use thin_vec::{thin_vec, ThinVec};
+    use thin_vec::{ThinVec, thin_vec};
 
     // Since this is only used for testing, using a string instead of an enum is fine.
     pub struct NodeCounterVisitor {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Break expressions can now carry an optional value and are supported throughout the language flow and printing.

* **Display**
  * Break expressions are rendered in the pretty-printer, including optional value formatting and indentation.

* **Tests**
  * Visitor tests updated and expanded to verify Break expression visitation (with and without values).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->