### PR TITLE
refactor: Make `return` an expression

### DIFF
--- a/src/ast/display.rs
+++ b/src/ast/display.rs
@@ -340,17 +340,6 @@ pub fn write_stmt(out: &mut String, stmt: &Stmt, ctx: &DisplayContext) -> std::f
                 write_fn_decl(out, fn_decl, &sub_ctx)?;
             }
         }
-        StmtKind::Return(return_stmt) => {
-            write!(out, "{}:", "Return".with_color(ctx.color),)?;
-            if let Some(value) = &return_stmt.value {
-                writeln!(out)?;
-                let value_ctx = ctx.indented();
-                write!(out, "{}", value_ctx.indent_str())?;
-                write_expr(out, value, &value_ctx)?;
-            } else {
-                write!(out, " (empty)")?;
-            }
-        }
         StmtKind::Import(import_stmt) => {
             write!(out, "{}: ", "Import".with_color(ctx.color),)?;
             write_import_tree(out, &import_stmt.tree, ctx)?;
@@ -596,9 +585,18 @@ fn write_expr(out: &mut String, expr: &Expr, ctx: &DisplayContext) -> std::fmt::
                 }
             }
         }
-        ExprKind::Break(break_expr) => {
-            write!(out, "{}", "Break".with_color(ctx.color),)?;
-            if let Some(value) = &break_expr.value {
+        ExprKind::Break(b) => {
+            write!(out, "{}", "Break".with_color(ctx.color))?;
+            if let Some(value) = &b.value {
+                writeln!(out, ":")?;
+                let value_ctx = ctx.indented();
+                write!(out, "{}", value_ctx.indent_str())?;
+                write_expr(out, value, &value_ctx)?;
+            }
+        }
+        ExprKind::Return(r) => {
+            write!(out, "{}", "Return".with_color(ctx.color))?;
+            if let Some(value) = &r.value {
                 writeln!(out, ":")?;
                 let value_ctx = ctx.indented();
                 write!(out, "{}", value_ctx.indent_str())?;

--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -105,3 +105,8 @@ pub struct LoopExpr {
 pub struct BreakExpr {
     pub value: Option<Box<Expr>>,
 }
+
+#[derive(Debug, Clone)]
+pub struct ReturnExpr {
+    pub value: Option<Box<Expr>>,
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -57,7 +57,6 @@ pub enum StmtKind {
     InterfaceDecl(InterfaceDeclStmt),
     Impl(ImplStmt),
     FnDecl(FnDeclStmt),
-    Return(ReturnStmt),
     Import(ImportStmt),
 }
 
@@ -87,6 +86,7 @@ pub enum ExprKind {
     While(WhileExpr),
     Loop(LoopExpr),
     Break(BreakExpr),
+    Return(ReturnExpr),
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -82,11 +82,6 @@ pub struct FnDeclStmt {
 }
 
 #[derive(Debug, Clone)]
-pub struct ReturnStmt {
-    pub value: Option<Expr>,
-}
-
-#[derive(Debug, Clone)]
 pub struct ImportStmt {
     pub tree: ImportTree,
     pub visibility: Visibility,

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -139,21 +139,6 @@ impl Visitor for AstValidator {
 
                 VisitAction::SkipChildren
             }
-            StmtKind::Return(r) => {
-                if !self.in_function {
-                    error_at!(
-                        stmt.span,
-                        self.module_id,
-                        "Return statement outside of function"
-                    )
-                    .expect("failed to emit error");
-                }
-                if let Some(val) = &r.value {
-                    val.visit(self);
-                }
-
-                VisitAction::SkipChildren
-            }
             StmtKind::VarDecl(v) => {
                 if !self.is_top_level && v.visibility == Visibility::Public {
                     error_at!(
@@ -221,6 +206,22 @@ impl Visitor for AstValidator {
 
                 VisitAction::SkipChildren
             }
+            ExprKind::Return(r) => {
+                if !self.in_function {
+                    error_at!(
+                        expr.span,
+                        self.module_id,
+                        "Return statement outside of function"
+                    )
+                    .expect("failed to emit error");
+                }
+                if let Some(val) = &r.value {
+                    val.visit(self);
+                }
+
+                VisitAction::SkipChildren
+            }
+
             _ => VisitAction::Continue,
         }
     }

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -104,7 +104,6 @@ impl Visitable for Stmt {
                 StmtKind::InterfaceDecl(i) => i.visit(visitor),
                 StmtKind::Impl(i) => i.visit(visitor),
                 StmtKind::FnDecl(f) => f.visit(visitor),
-                StmtKind::Return(r) => r.visit(visitor),
                 StmtKind::Import(i) => i.visit(visitor),
             },
             VisitAction::SkipChildren => {}
@@ -209,14 +208,6 @@ impl Visitable for FnDeclStmt {
     }
 }
 
-impl Visitable for ReturnStmt {
-    fn visit(&self, visitor: &mut impl Visitor) {
-        if let Some(v) = &self.value {
-            v.visit(visitor);
-        }
-    }
-}
-
 impl Visitable for Expr {
     fn visit(&self, visitor: &mut impl Visitor) {
         match visitor.visit_expr(self) {
@@ -239,6 +230,7 @@ impl Visitable for Expr {
                 ExprKind::As(a) => a.visit(visitor),
                 ExprKind::TupleLiteral(t) => t.visit(visitor),
                 ExprKind::Break(b) => b.visit(visitor),
+                ExprKind::Return(r) => r.visit(visitor),
             },
             VisitAction::SkipChildren => {}
         }
@@ -279,6 +271,14 @@ impl Visitable for LoopExpr {
 }
 
 impl Visitable for BreakExpr {
+    fn visit(&self, visitor: &mut impl Visitor) {
+        if let Some(v) = &self.value {
+            v.visit(visitor);
+        }
+    }
+}
+
+impl Visitable for ReturnExpr {
     fn visit(&self, visitor: &mut impl Visitor) {
         if let Some(v) = &self.value {
             v.visit(visitor);

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -494,7 +494,7 @@ fn compile_return<'ctx>(
             let casted = cast_int_to_type(builder, ret_val, expected_type)?;
             builder.build_return(Some(&casted))?;
         } else {
-            builder.build_return(Some(&ret_val))?;
+            bail!("cannot return a value from a void function");
         }
     } else {
         builder.build_return(None)?;

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -497,7 +497,18 @@ fn compile_return<'ctx>(
             bail!("cannot return a value from a void function");
         }
     } else {
-        builder.build_return(None)?;
+        let function = builder
+            .get_insert_block()
+            .expect("function has a block")
+            .get_parent()
+            .expect("block has a function");
+        let expected_ret_type = function.get_type().get_return_type();
+
+        if expected_ret_type.is_some() {
+            bail!("cannot return a value from a void function");
+        } else {
+            builder.build_return(None)?;
+        }
     }
 
     Ok(())

--- a/src/codegen/compile_expr.rs
+++ b/src/codegen/compile_expr.rs
@@ -9,7 +9,7 @@ use inkwell::{
 };
 
 use crate::{
-    ast::{Expr, ExprKind, Literal, Type, TypeKind, types::SliceType},
+    ast::{Expr, ExprKind, Literal, Type, TypeKind, expressions::ReturnExpr, types::SliceType},
     codegen::{
         arch::compile_arch_size_type,
         builtin::{Builtin, get_builtin},
@@ -443,6 +443,14 @@ pub fn compile_expression_to_value<'a, 'ctx>(
 
             SmartValue::from_value(slice_val.as_basic_value_enum())
         }
+        ExprKind::Return(ret) => {
+            compile_return(context, module, builder, ret, compilation_context)?;
+            SmartValue::from_value(
+                compile_arch_size_type(context)
+                    .const_int(0, false)
+                    .as_basic_value_enum(),
+            )
+        }
         // TODO: Return the value of the last expression in the block
         ExprKind::Block(block) => {
             let mut inner_compilation_context = compilation_context.clone();
@@ -461,4 +469,36 @@ pub fn compile_expression_to_value<'a, 'ctx>(
         }
         expr => unimplemented!("{expr:#?}"),
     })
+}
+
+fn compile_return<'ctx>(
+    context: &'ctx Context,
+    module: &Module<'ctx>,
+    builder: &Builder<'ctx>,
+    ret: &ReturnExpr,
+    compilation_context: &mut CompilationContext<'ctx>,
+) -> Result<()> {
+    if let Some(expr) = &ret.value {
+        let ret = compile_expression_to_value(context, module, builder, expr, compilation_context)?;
+
+        let ret_val = ret.unwrap(builder)?;
+
+        let function = builder
+            .get_insert_block()
+            .expect("function has a block")
+            .get_parent()
+            .expect("block has a function");
+        let expected_ret_type = function.get_type().get_return_type();
+
+        if let Some(expected_type) = expected_ret_type {
+            let casted = cast_int_to_type(builder, ret_val, expected_type)?;
+            builder.build_return(Some(&casted))?;
+        } else {
+            builder.build_return(Some(&ret_val))?;
+        }
+    } else {
+        builder.build_return(None)?;
+    }
+
+    Ok(())
 }

--- a/src/codegen/compiler.rs
+++ b/src/codegen/compiler.rs
@@ -13,13 +13,13 @@ use inkwell::{
 use crate::{
     ast::{
         Stmt, StmtKind, Type,
-        statements::{ExprStmt, FnDeclStmt, ReturnStmt, StructDeclStmt, VarDeclStmt},
+        statements::{ExprStmt, FnDeclStmt, StructDeclStmt, VarDeclStmt},
     },
     bindings::llvm_bindings::create_named_struct,
     codegen::{
         builtin::Builtin,
         compile_expr::compile_expression_to_value,
-        compile_type::{cast_int_to_type, compile_function_type, compile_type},
+        compile_type::{compile_function_type, compile_type},
         inkwell_ext::add_global_constant,
         pointer::SmartValue,
     },
@@ -170,9 +170,6 @@ pub fn compile_stmts<'a, 'ctx>(
                     )?;
                 }
             }
-            StmtKind::Return(ret_stmt) => {
-                compile_return(context, module, builder, ret_stmt, compilation_context)?;
-            }
             StmtKind::Expr(expr_stmt) => {
                 compile_expression(context, module, builder, expr_stmt, compilation_context)?;
             }
@@ -278,38 +275,6 @@ fn compile_function<'ctx>(
                 .as_basic_type_enum(),
         ),
     );
-
-    Ok(())
-}
-
-fn compile_return<'ctx>(
-    context: &'ctx Context,
-    module: &Module<'ctx>,
-    builder: &Builder<'ctx>,
-    ret_stmt: &ReturnStmt,
-    compilation_context: &mut CompilationContext<'ctx>,
-) -> Result<()> {
-    if let Some(expr) = &ret_stmt.value {
-        let ret = compile_expression_to_value(context, module, builder, expr, compilation_context)?;
-
-        let ret_val = ret.unwrap(builder)?;
-
-        let function = builder
-            .get_insert_block()
-            .expect("function has a block")
-            .get_parent()
-            .expect("block has a function");
-        let expected_ret_type = function.get_type().get_return_type();
-
-        if let Some(expected_type) = expected_ret_type {
-            let casted = cast_int_to_type(builder, ret_val, expected_type)?;
-            builder.build_return(Some(&casted))?;
-        } else {
-            builder.build_return(Some(&ret_val))?;
-        }
-    } else {
-        builder.build_return(None)?;
-    }
 
     Ok(())
 }

--- a/src/hir/lower.rs
+++ b/src/hir/lower.rs
@@ -701,6 +701,10 @@ impl LoweringContext {
                 let value = b.value.map(|e| self.lower_expr(*e));
                 self.alloc_expr(HirExpr::Break { value })
             }
+            ExprKind::Return(r) => {
+                let value = r.value.map(|e| self.lower_expr(*e));
+                self.alloc_expr(HirExpr::Return { value })
+            }
             _ => todo!("Lowering of {:?} not implemented", expr.kind),
         }
     }
@@ -737,10 +741,6 @@ impl LoweringContext {
                     local,
                 };
                 self.alloc_stmt(var)
-            }
-            StmtKind::Return(r) => {
-                let val = r.value.map(|e| self.lower_expr(e));
-                self.alloc_stmt(HirStmt::Return(val))
             }
             _ => todo!("Lowering of {:?} not implemented", stmt.kind),
         }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -249,6 +249,9 @@ pub enum HirExpr {
     Break {
         value: Option<ExprId>,
     },
+    Return {
+        value: Option<ExprId>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -263,7 +266,6 @@ pub enum HirStmt {
         init: ExprId,
         local: LocalId,
     },
-    Return(Option<ExprId>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -452,11 +452,7 @@ pub fn parse_loop_expr(parser: &mut Parser) -> Result<Expr> {
 pub fn parse_break_expr(parser: &mut Parser) -> Result<Expr> {
     let start_span = parser.expect(TokenKind::Break)?.span;
 
-    let current = parser.current_token().kind;
-    let value = if !matches!(
-        current,
-        TokenKind::Semicolon | TokenKind::CloseCurly | TokenKind::Comma
-    ) {
+    let value = if has_expr(parser) {
         Some(Box::new(parse_expr(parser, BindingPower::DefaultBp)?))
     } else {
         None
@@ -469,4 +465,30 @@ pub fn parse_break_expr(parser: &mut Parser) -> Result<Expr> {
         kind: ExprKind::Break(BreakExpr { value }),
         span,
     })
+}
+
+pub fn parse_return_expr(parser: &mut Parser) -> Result<Expr> {
+    let start_span = parser.expect(TokenKind::Return)?.span;
+
+    let value = if has_expr(parser) {
+        Some(Box::new(parse_expr(parser, BindingPower::DefaultBp)?))
+    } else {
+        None
+    };
+
+    let end_span = value.as_ref().map(|v| v.span).unwrap_or(start_span);
+    let span = Span::new(start_span.start(), end_span.end());
+
+    Ok(Expr {
+        kind: ExprKind::Return(ReturnExpr { value }),
+        span,
+    })
+}
+
+fn has_expr(parser: &mut Parser) -> bool {
+    let current = parser.current_token().kind;
+    !matches!(
+        current,
+        TokenKind::Semicolon | TokenKind::CloseCurly | TokenKind::Comma
+    )
 }

--- a/src/parser/lookups.rs
+++ b/src/parser/lookups.rs
@@ -275,6 +275,7 @@ pub fn create_token_lookups() {
         nud(T::While, parse_while_expr, &mut nud_lu);
         nud(T::Loop, parse_loop_expr, &mut nud_lu);
         nud(T::Break, parse_break_expr, &mut nud_lu);
+        nud(T::Return, parse_return_expr, &mut nud_lu);
 
         // Statements
         stmt(T::Let, parse_var_decl_statement, &mut bp_lu, &mut stmt_lu);
@@ -294,7 +295,6 @@ pub fn create_token_lookups() {
         );
         stmt(T::Impl, parse_impl_stmt, &mut bp_lu, &mut stmt_lu);
         stmt(T::Fn, parse_fn_decl_stmt, &mut bp_lu, &mut stmt_lu);
-        stmt(T::Return, parse_return_stmt, &mut bp_lu, &mut stmt_lu);
         stmt(T::Import, parse_import_stmt, &mut bp_lu, &mut stmt_lu);
 
         let _ = BP_LU.set(bp_lu);

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -443,33 +443,6 @@ pub fn parse_fn_decl_stmt(
     })
 }
 
-pub fn parse_return_stmt(
-    parser: &mut Parser,
-    attributes: ThinVec<Attribute>,
-    modifiers: ThinVec<Modifier>,
-) -> Result<Stmt> {
-    no_attributes!(&parser, &attributes);
-    no_modifiers!(&parser, &modifiers);
-
-    let return_token = parser.advance();
-
-    let value = if parser.current_token().kind != TokenKind::Semicolon {
-        Some(parse_expr(parser, BindingPower::DefaultBp)?)
-    } else {
-        None
-    };
-
-    let end_span = parser.expect(TokenKind::Semicolon)?.span;
-
-    let span = Span::new(return_token.span.start(), end_span.end());
-
-    Ok(Stmt {
-        kind: StmtKind::Return(ReturnStmt { value }),
-        attributes,
-        span,
-    })
-}
-
 pub fn parse_impl_stmt(
     parser: &mut Parser,
     attributes: ThinVec<Attribute>,

--- a/tests/visit_tests.rs
+++ b/tests/visit_tests.rs
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn test_return_stmt_no_value() {
+    fn test_return_no_value() {
         let expr = Expr {
             kind: ExprKind::Return(ReturnExpr { value: None }),
             span: dummy_span(),

--- a/tests/visit_tests.rs
+++ b/tests/visit_tests.rs
@@ -12,7 +12,7 @@ mod tests {
         lexer::token::{Token, TokenKind},
         span::{ModuleId, Span},
     };
-    use thin_vec::{thin_vec, ThinVec};
+    use thin_vec::{ThinVec, thin_vec};
 
     // Since this is only used for testing, using a string instead of an enum is fine.
     pub struct NodeCounterVisitor {
@@ -81,7 +81,6 @@ mod tests {
                 StmtKind::StructDecl(_) => "StructDeclStmt",
                 StmtKind::InterfaceDecl(_) => "InterfaceDeclStmt",
                 StmtKind::FnDecl(_) => "FnDeclStmt",
-                StmtKind::Return(_) => "ReturnStmt",
                 StmtKind::Import(_) => "ImportStmt",
                 StmtKind::Impl(_) => "ImplStmt",
                 StmtKind::Semi(_) => "SemiStmt",
@@ -121,6 +120,7 @@ mod tests {
                 ExprKind::As(_) => "AsExpr",
                 ExprKind::TupleLiteral(_) => "TupleLiteralExpr",
                 ExprKind::Break(_) => "BreakExpr",
+                ExprKind::Return(_) => "ReturnExpr",
             };
             *self.expr_counts.entry(kind_name).or_insert(0) += 1;
 
@@ -767,33 +767,30 @@ mod tests {
     }
 
     #[test]
-    fn test_return_stmt_with_value() {
-        let stmt = Stmt {
-            kind: StmtKind::Return(ReturnStmt {
-                value: Some(dummy_expr_number(1)),
+    fn test_return_with_value() {
+        let expr = Expr {
+            kind: ExprKind::Return(ReturnExpr {
+                value: Some(Box::new(dummy_expr_number(1))),
             }),
             span: dummy_span(),
-            attributes: ThinVec::new(),
         };
         let mut visitor = NodeCounterVisitor::new();
-        stmt.visit(&mut visitor);
-        visitor.assert_visited("stmt", "Stmt", 1);
-        visitor.assert_visited("stmt", "ReturnStmt", 1);
-        visitor.assert_visited("expr", "Expr", 1);
+        expr.visit(&mut visitor);
+        visitor.assert_visited("expr", "Expr", 2);
+        visitor.assert_visited("expr", "ReturnExpr", 1);
         visitor.assert_visited("expr", "NumberExpr", 1);
     }
 
     #[test]
     fn test_return_stmt_no_value() {
-        let stmt = Stmt {
-            kind: StmtKind::Return(ReturnStmt { value: None }),
+        let expr = Expr {
+            kind: ExprKind::Return(ReturnExpr { value: None }),
             span: dummy_span(),
-            attributes: ThinVec::new(),
         };
         let mut visitor = NodeCounterVisitor::new();
-        stmt.visit(&mut visitor);
-        visitor.assert_visited("stmt", "Stmt", 1);
-        visitor.assert_visited("stmt", "ReturnStmt", 1);
+        expr.visit(&mut visitor);
+        visitor.assert_visited("expr", "Expr", 1);
+        visitor.assert_visited("expr", "ReturnExpr", 1);
     }
 
     #[test]
@@ -1073,8 +1070,17 @@ mod tests {
                                             kind: ExprKind::Block(BlockExpr {
                                                 block: Block {
                                                     stmts: thin_vec![Stmt {
-                                                        kind: StmtKind::Return(ReturnStmt {
-                                                            value: Some(dummy_expr_number(2)),
+                                                        kind: StmtKind::Semi(SemiStmt {
+                                                            expr: Expr {
+                                                                kind: ExprKind::Return(
+                                                                    ReturnExpr {
+                                                                        value: Some(Box::new(
+                                                                            dummy_expr_number(2)
+                                                                        ))
+                                                                    }
+                                                                ),
+                                                                span: dummy_span()
+                                                            }
                                                         }),
                                                         span: dummy_span(),
                                                         attributes: ThinVec::new(),
@@ -1109,7 +1115,7 @@ mod tests {
             ("stmt", "FnDeclStmt", 1),
             ("stmt", "VarDeclStmt", 1),
             ("expr", "BlockExpr", 1),
-            ("stmt", "ReturnStmt", 1),
+            ("expr", "ReturnExpr", 1),
             ("stmt", "ExpressionStmt", 2),
         ]);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Return is now an expression, permitting returns inside expressions for more flexible control flow.

* **Refactor**
  * Return handling migrated from statement-level to expression-level across parsing, validation, lowering, visitation, and code generation.

* **Tests**
  * Updated tests and visit assertions to reflect the return-as-expression model and adjusted expected counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->