### PR TITLE
refactor: Add impl blocks to HIR

### DIFF
--- a/src/hir/interner.rs
+++ b/src/hir/interner.rs
@@ -4,7 +4,9 @@ pub type Symbol = u32;
 
 #[derive(Debug, Default, Clone)]
 pub struct Interner {
+    /// Used for checking if a symbol is already interned
     map: FxHashMap<String, Symbol>,
+    /// Used for retreaving the symbol value
     vec: Vec<String>,
 }
 

--- a/src/hir/interner.rs
+++ b/src/hir/interner.rs
@@ -6,7 +6,7 @@ pub type Symbol = u32;
 pub struct Interner {
     /// Used for checking if a symbol is already interned
     map: FxHashMap<String, Symbol>,
-    /// Used for retreaving the symbol value
+    /// Used for retrieving the symbol value
     vec: Vec<String>,
 }
 

--- a/src/hir/lower.rs
+++ b/src/hir/lower.rs
@@ -389,12 +389,15 @@ impl LoweringContext {
 
     fn alloc_impl_item(&mut self, kind: ImplItemKind, span: Span) -> ImplItemId {
         let id = ImplItemId(self.krate.impl_items.len() as u32);
-        self.krate.impl_items.push(ImplItem {
-            defid: DefId(self.next_def),
-            kind,
+        let modid = self.current_module.expect("current module set");
+        let defid = DefId(self.next_def);
+        self.krate.impl_items.push(ImplItem { defid, kind, span });
+        self.next_def += 1;
+        self.krate.items.push(HirItem {
+            defid,
+            kind: HirItemKind::Placeholder(modid),
             span,
         });
-        self.next_def += 1;
         id
     }
 
@@ -445,6 +448,16 @@ impl LoweringContext {
                 return;
             }
         };
+
+        match &self.krate.items[interface_def.0 as usize].kind {
+            HirItemKind::Interface(_) => {}
+            _ => {
+                self.krate
+                    .diagnostics
+                    .push(format!("`{}` is not an interface", iface.value));
+                return;
+            }
+        }
 
         let self_defid = match &self_ty.kind {
             TypeKind::Symbol(s) => {
@@ -516,10 +529,11 @@ impl LoweringContext {
                 static_method: item.is_static,
             };
 
-            let impl_item_id = self.alloc_impl_item(ImplItemKind::Fn(func), item.span);
+            let impl_item_id = self.alloc_impl_item(ImplItemKind::Fn(func.clone()), item.span);
             impl_item_ids.push(impl_item_id);
 
             let method_defid = self.krate.impl_items[impl_item_id.0 as usize].defid;
+            self.krate.items[method_defid.0 as usize].kind = HirItemKind::Function(func);
             let method_map = &mut self.krate.modules[modid.0 as usize]
                 .struct_methods
                 .entry(self_defid)

--- a/src/hir/lower.rs
+++ b/src/hir/lower.rs
@@ -8,9 +8,9 @@ use crate::{
     hashmap::FxHashMap,
     hir::{
         Body, BodyId, DefId, ExportEntry, ExprId, Function, HirCrate, HirExpr, HirExprKind, HirId,
-        HirItem, HirItemKind, HirStmt, HirStmtKind, HirType, Interface, InterfaceMethod, LocalId,
-        LoopSource, MethodMeta, ModuleId, ModuleInfo, StmtId, Struct, StructField, TypeId,
-        Variable, interner::Symbol,
+        HirItem, HirItemKind, HirStmt, HirStmtKind, HirType, Impl, ImplItem, ImplItemId,
+        ImplItemKind, Interface, InterfaceMethod, LocalId, LoopSource, MethodMeta, ModuleId,
+        ModuleInfo, StmtId, Struct, StructField, TypeId, Variable, interner::Symbol,
     },
     lexer::token::TokenKind,
     span::Span,
@@ -84,6 +84,7 @@ impl LoweringContext {
                 struct_methods: FxHashMap::default(),
                 struct_fields: FxHashMap::default(),
                 struct_impls: FxHashMap::default(),
+                interface_impls: FxHashMap::default(),
             };
             self.krate.modules.push(modinfo);
         }
@@ -352,7 +353,6 @@ impl LoweringContext {
         let st = Struct {
             name: sym,
             fields,
-            methods: ThinVec::with_capacity(sitems.len()),
             module: modid,
         };
         let item = &mut self.krate.items[defid.0 as usize];
@@ -377,12 +377,6 @@ impl LoweringContext {
                 let method_defid = meta.def;
 
                 method_fns.push((fn_decl, method_defid, defid, item.is_static));
-
-                if let HirItemKind::Struct(st) = &mut self.krate.items[defid.0 as usize].kind {
-                    st.methods.push((method_sym, method_defid));
-                } else {
-                    panic!("struct defid must refer to Struct");
-                }
             }
         }
 
@@ -391,6 +385,17 @@ impl LoweringContext {
         }
 
         self.current_struct = prev_struct;
+    }
+
+    fn alloc_impl_item(&mut self, kind: ImplItemKind, span: Span) -> ImplItemId {
+        let id = ImplItemId(self.krate.impl_items.len() as u32);
+        self.krate.impl_items.push(ImplItem {
+            defid: DefId(self.next_def),
+            kind,
+            span,
+        });
+        self.next_def += 1;
+        id
     }
 
     fn lower_interface_decl(&mut self, iname: Ident, iitems: ThinVec<AssocItem>, span: Span) {
@@ -441,7 +446,7 @@ impl LoweringContext {
             }
         };
 
-        let self_defid = match self_ty.kind {
+        let self_defid = match &self_ty.kind {
             TypeKind::Symbol(s) => {
                 let sym = self.krate.interner.intern(&s.name.value);
                 match self.lookup_in_current_module(sym) {
@@ -462,7 +467,7 @@ impl LoweringContext {
             }
         };
 
-        let struct_modid = self.krate.items[self_defid.0 as usize].kind.module();
+        let modid = self.current_module.expect("current module set");
         match &self.krate.items[self_defid.0 as usize].kind {
             HirItemKind::Struct(_) => {}
             _ => {
@@ -473,18 +478,52 @@ impl LoweringContext {
             }
         }
 
+        let impl_defid = self.alloc_item_placeholder(self_ty.span);
+        let self_ty_id = self.lower_type(self_ty);
+
+        let mut impl_item_ids = ThinVec::with_capacity(items.len());
+
         for item in items.into_iter() {
             let AssocItemKind::Fn(fn_decl) = item.kind;
             let method_sym = self.krate.interner.intern(&fn_decl.name.value);
-            let method_defid = self.alloc_item_placeholder(item.span);
 
-            self.lower_fn_impl(fn_decl, method_defid, Some(self_defid), item.is_static);
+            let param_names: ThinVec<Symbol> = fn_decl
+                .parameters
+                .iter()
+                .map(|(pname, _)| self.krate.interner.intern(&pname.value))
+                .collect();
 
-            let method_map = &mut self.krate.modules[struct_modid.0 as usize]
+            let params = fn_decl
+                .parameters
+                .into_iter()
+                .map(|(pname, pty)| {
+                    (
+                        self.krate.interner.intern(&pname.value),
+                        self.lower_type(pty),
+                    )
+                })
+                .collect();
+
+            let ret = self.lower_type(fn_decl.return_type);
+
+            let func = Function {
+                name: method_sym,
+                params,
+                ret,
+                body: None,
+                module: modid,
+                associated: Some(self_defid),
+                static_method: item.is_static,
+            };
+
+            let impl_item_id = self.alloc_impl_item(ImplItemKind::Fn(func), item.span);
+            impl_item_ids.push(impl_item_id);
+
+            let method_defid = self.krate.impl_items[impl_item_id.0 as usize].defid;
+            let method_map = &mut self.krate.modules[modid.0 as usize]
                 .struct_methods
                 .entry(self_defid)
                 .or_default();
-
             method_map.insert(
                 method_sym,
                 MethodMeta {
@@ -493,13 +532,54 @@ impl LoweringContext {
                     visibility: item.visibility,
                 },
             );
+
+            if let Some(body) = fn_decl.body {
+                self.with_owner(method_defid, |ctx| {
+                    ctx.local_stack.push(FxHashMap::default());
+
+                    for pname in param_names {
+                        let local = ctx.alloc_local();
+                        ctx.local_stack
+                            .last_mut()
+                            .expect("local stack exists")
+                            .insert(pname, local);
+                    }
+
+                    let stmt_ids: ThinVec<StmtId> = body
+                        .stmts
+                        .into_iter()
+                        .map(|stmt| ctx.lower_stmt(stmt))
+                        .collect();
+
+                    let body_id = ctx.alloc_body(Body { stmts: stmt_ids });
+                    let ImplItemKind::Fn(func) =
+                        &mut ctx.krate.impl_items[impl_item_id.0 as usize].kind;
+                    func.body = Some(body_id);
+                    ctx.local_stack.pop();
+                });
+            }
         }
 
-        self.krate.modules[struct_modid.0 as usize]
+        let impl_item = Impl {
+            self_ty: self_ty_id,
+            of_interface: interface_def,
+            items: impl_item_ids,
+            module: modid,
+        };
+
+        self.krate.items[impl_defid.0 as usize].kind = HirItemKind::Impl(impl_item);
+
+        self.krate.modules[modid.0 as usize]
             .struct_impls
             .entry(self_defid)
             .or_default()
-            .push(interface_def);
+            .push(impl_defid);
+
+        self.krate.modules[modid.0 as usize]
+            .interface_impls
+            .entry(interface_def)
+            .or_default()
+            .push(impl_defid);
     }
 
     fn lower_static_item(&mut self, sname: Ident, sty: Type, svalue: Expr, span: Span) {

--- a/src/hir/lower.rs
+++ b/src/hir/lower.rs
@@ -569,6 +569,11 @@ impl LoweringContext {
                     let ImplItemKind::Fn(func) =
                         &mut ctx.krate.impl_items[impl_item_id.0 as usize].kind;
                     func.body = Some(body_id);
+                    if let HirItemKind::Function(item_func) =
+                        &mut ctx.krate.items[method_defid.0 as usize].kind
+                    {
+                        item_func.body = Some(body_id);
+                    }
                     ctx.local_stack.pop();
                 });
             }

--- a/src/hir/lower.rs
+++ b/src/hir/lower.rs
@@ -496,6 +496,8 @@ impl LoweringContext {
 
         let mut impl_item_ids = ThinVec::with_capacity(items.len());
 
+        let prev_struct = self.current_struct;
+        self.current_struct = Some(self_defid);
         for item in items.into_iter() {
             let AssocItemKind::Fn(fn_decl) = item.kind;
             let method_sym = self.krate.interner.intern(&fn_decl.name.value);
@@ -578,6 +580,7 @@ impl LoweringContext {
                 });
             }
         }
+        self.current_struct = prev_struct;
 
         let impl_item = Impl {
             self_ty: self_ty_id,

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -51,6 +51,9 @@ pub struct ModuleId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BodyId(pub u32);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImplItemId(pub u32);
+
 impl From<u32> for DefId {
     fn from(v: u32) -> Self {
         DefId(v)
@@ -86,11 +89,17 @@ impl From<u32> for BodyId {
         BodyId(v)
     }
 }
+impl From<u32> for ImplItemId {
+    fn from(v: u32) -> Self {
+        ImplItemId(v)
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct HirCrate {
     pub modules: ThinVec<ModuleInfo>,
     pub items: ThinVec<HirItem>,
+    pub impl_items: ThinVec<ImplItem>,
     pub exprs: ThinVec<HirExpr>,
     pub types: ThinVec<HirType>,
     pub stmts: ThinVec<HirStmt>,
@@ -149,6 +158,16 @@ impl HirCrate {
         );
         &self.types[id.0 as usize]
     }
+
+    pub fn impl_item(&self, id: ImplItemId) -> &ImplItem {
+        debug_assert!(
+            (id.0 as usize) < self.impl_items.len(),
+            "ImplItemId({}) out of bounds (len={})",
+            id.0,
+            self.impl_items.len()
+        );
+        &self.impl_items[id.0 as usize]
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -157,9 +176,13 @@ pub struct ModuleInfo {
     pub exports: FxHashMap<Symbol, ExportEntry>,
     pub items: ThinVec<DefId>,
     pub imports: FxHashMap<Symbol, DefId>,
+    /// Maps struct DefId -> method name -> metadata
     pub struct_methods: FxHashMap<DefId, FxHashMap<Symbol, MethodMeta>>,
     pub struct_fields: FxHashMap<DefId, FxHashMap<Symbol, Visibility>>,
+    /// Maps struct DefId -> impl block DefIds
     pub struct_impls: FxHashMap<DefId, ThinVec<DefId>>,
+    /// Maps interface DefId -> impl block DefIds
+    pub interface_impls: FxHashMap<DefId, ThinVec<DefId>>,
 }
 
 #[derive(Debug, Clone)]
@@ -188,6 +211,7 @@ pub enum HirItemKind {
     Struct(Struct),
     Interface(Interface),
     Variable(Variable),
+    Impl(Impl),
 }
 
 impl HirItemKind {
@@ -198,6 +222,7 @@ impl HirItemKind {
             HirItemKind::Struct(s) => s.module,
             HirItemKind::Interface(i) => i.module,
             HirItemKind::Variable(v) => v.module,
+            HirItemKind::Impl(imp) => imp.module,
         }
     }
 }
@@ -240,7 +265,14 @@ pub struct StructField {
 pub struct Struct {
     pub name: Symbol,
     pub fields: ThinVec<StructField>,
-    pub methods: ThinVec<(Symbol, DefId)>,
+    pub module: ModuleId,
+}
+
+#[derive(Debug, Clone)]
+pub struct Impl {
+    pub self_ty: TypeId,
+    pub of_interface: DefId,
+    pub items: ThinVec<ImplItemId>,
     pub module: ModuleId,
 }
 
@@ -271,6 +303,18 @@ pub struct MethodMeta {
     pub def: DefId,
     pub is_static: bool,
     pub visibility: Visibility,
+}
+
+#[derive(Debug, Clone)]
+pub struct ImplItem {
+    pub defid: DefId,
+    pub kind: ImplItemKind,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImplItemKind {
+    Fn(Function),
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked impl/ method representation: methods moved out of type objects into per-impl items and per-module maps; modules now track impls and interface implementations for clearer wiring and lookup.
  * Method bodies and metadata are now associated via impl-centric items rather than per-struct entries.

* **Documentation**
  * Minor inline comments added to interner fields for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->